### PR TITLE
Feat: Config method that returns GH token, username and repo

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,15 @@
+// config.js
+const config = {
+  githubOwner: import.meta.env.VUE_APP_GITHUB_OWNER || "",
+  githubRepo: import.meta.env.VUE_APP_GITHUB_REPO || "",
+  githubAuthToken: async () => {
+    async function getGithubAuthToken() {
+      // Fetch GitHub Token through API or through event listeners or through other functions
+      return ""; // return the token here
+    }
+
+    return import.meta.env.VUE_APP_GITHUB_TOKEN || (await getGithubAuthToken());
+  },
+};
+
+export default config;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -6,12 +6,13 @@ import {
   checkStatusFromRefHead,
   sessionReviewStatus,
 } from "@/api/session";
+import config from "@/../config.js";
 
-const githubConfig = {
-  auth: import.meta.env.VUE_APP_GITHUB_TOKEN,
-  username: import.meta.env.VUE_APP_GITHUB_OWNER,
-  repo: import.meta.env.VUE_APP_GITHUB_REPO,
-};
+const auth = await config.githubAuthToken();
+const username = config.githubOwner;
+const repo = config.githubRepo;
+
+const githubConfig = { auth, username, repo };
 
 const octokit = new Octokit({ auth: githubConfig.auth });
 


### PR DESCRIPTION
GitHub token, ownername and repo now can be fetched from `config.js` in the root. If anyone need to add their own credentials they can update that file through - 
- Adding an env 
- Adding a static value return 
- Or by creating async function to get the credentials through a hook. 