### PR TITLE
Fix: Remove snackbar warning due to wrong property declarartion rather than using inject

### DIFF
--- a/src/components/file/ActionTabFileList.vue
+++ b/src/components/file/ActionTabFileList.vue
@@ -29,7 +29,6 @@ const props = defineProps({
       tab
       size="x-large"
       :session="props.session"
-      :snackbar="snackbar"
       :callBack="props.updateDetails"
     />
     <v-divider
@@ -61,7 +60,6 @@ const props = defineProps({
       color="blue-grey-lighten-4"
       variant="flat"
       :session="props.session"
-      :snackbar="snackbar"
       :callBack="props.updateDetails"
       class="ml-5"
     />

--- a/src/components/session/ActionList.vue
+++ b/src/components/session/ActionList.vue
@@ -7,10 +7,6 @@ defineProps({
     type: Object,
     required: true,
   },
-  snackbar: {
-    type: Object,
-    required: true,
-  },
   callBack: {
     type: Function,
     required: true,
@@ -20,7 +16,7 @@ defineProps({
 
 <template>
   <div class="d-none d-sm-flex">
-    <Actions :session="session" :snackbar="snackbar" :callBack="callBack" />
+    <Actions :session="session" :callBack="callBack" />
   </div>
   <div class="d-flex d-sm-none">
     <v-menu :close-on-content-click="false">
@@ -33,7 +29,7 @@ defineProps({
         ></v-btn>
       </template>
       <v-list>
-        <Actions :session="session" :snackbar="snackbar" :callBack="callBack" />
+        <Actions :session="session" :callBack="callBack" />
       </v-list>
     </v-menu>
   </div>

--- a/src/components/session/Actions.vue
+++ b/src/components/session/Actions.vue
@@ -8,13 +8,12 @@ import {
 
 const props = defineProps({
   session: Object,
-  snackbar: Object,
   callBack: Function,
 });
 </script>
 
 <template>
   <GithubSession :url="session.html_url" />
-  <ReviewSession :session="session" :snackbar="snackbar" :callBack="callBack" />
-  <DeleteSession :session="session" :snackbar="snackbar" :callBack="callBack" />
+  <ReviewSession :session="session" :callBack="callBack" />
+  <DeleteSession :session="session" :callBack="callBack" />
 </template>

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -189,11 +189,7 @@ const onPageChange = async (newPage) => {
       </template>
 
       <template v-slot:append>
-        <ActionList
-          :session="session"
-          :snackbar="snackbar"
-          :callBack="updateSessionsList"
-        />
+        <ActionList :session="session" :callBack="updateSessionsList" />
       </template>
     </v-list-item>
 


### PR DESCRIPTION
## Implementation 
- Remove `:snackbar` props from component and rather than using `const snackbar = inject("set-snackbar");` in each component to avoid multiple loop warnings

![image](https://github.com/user-attachments/assets/f93f3711-1649-46b7-8555-51c2fa7e4366)
