### PR TITLE
Fix: order new json keys with old content

### DIFF
--- a/src/helpers/transform.js
+++ b/src/helpers/transform.js
@@ -1,10 +1,37 @@
-export function stringifyIfNeeded(value) {
+export function stringifyIfNeeded(value, oldContent) {
   if (value === null) {
     return null;
   }
 
   if (typeof value === "object") {
-    return JSON.stringify(value, "", 2);
+    if (oldContent) {
+      const oldOrder = JSON.parse(oldContent);
+      const getOrderedKeys = (obj, oldObj) => {
+        const oldKeys = Object.keys(oldObj || {});
+        const newKeys = Object.keys(obj || {});
+        return [...new Set([...oldKeys, ...newKeys])];
+      };
+
+      const orderObject = (obj, oldObj) => {
+        if (!obj || typeof obj !== "object") return obj;
+
+        const ordered = {};
+        getOrderedKeys(obj, oldObj).forEach((key) => {
+          if (key in obj) {
+            ordered[key] =
+              typeof obj[key] === "object" && obj[key] !== null
+                ? orderObject(obj[key], oldObj?.[key])
+                : obj[key];
+          }
+        });
+        return ordered;
+      };
+
+      const orderedValue = orderObject(value, oldOrder);
+      return JSON.stringify(orderedValue, null, 2);
+    } else {
+      return JSON.stringify(value, null, 2);
+    }
   }
 
   return value;

--- a/src/views/FileEditView.vue
+++ b/src/views/FileEditView.vue
@@ -94,6 +94,7 @@ const saveFile = async () => {
           schemaMetaDetails.value.output
             ? updatedFileContent.value[schemaMetaDetails.value.output]
             : updatedFileContent.value,
+          decodeString(file.value.content),
         )
       : updatedFileContent.value,
     file.value.sha,


### PR DESCRIPTION
## Implemented changes 
- Comparing old content JSON's `keys` with the new content JSON's key and then order it accordinly