### PR TITLE
Fix: remove symbols from branch's slug name

### DIFF
--- a/src/api/session.js
+++ b/src/api/session.js
@@ -38,7 +38,10 @@ export async function sessionsList(
 export async function createSession(octokit, githubConfig, prName) {
   const { username: owner, repo } = githubConfig;
   const username = (await octokit.rest.users.getAuthenticated()).data.login;
-  const slugifiedPrName = slugify(prName, { lower: true });
+  const slugifiedPrName = slugify(prName, {
+    lower: true,
+    remove: /[*+~.()'"!:@]/g,
+  });
   const forkBranchName = `${username}/${slugifiedPrName}`;
 
   try {

--- a/src/api/session.js
+++ b/src/api/session.js
@@ -40,7 +40,7 @@ export async function createSession(octokit, githubConfig, prName) {
   const username = (await octokit.rest.users.getAuthenticated()).data.login;
   const slugifiedPrName = slugify(prName, {
     lower: true,
-    remove: /[*+~.()'"!:@]/g,
+    strict: true,
   });
   const forkBranchName = `${username}/${slugifiedPrName}`;
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fddf9cf4-d9a2-432a-ad6b-7c7984ab091f)

- Removed symbols from branch's slugified name. 