### PR TITLE
fix(ci): add permission to publish packages to workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 env:
   IMAGE_NAME: ghcr.io/eox-a/git-clerk:${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
Adding missing permission in order to push images (see [related issue](https://github.com/orgs/community/discussions/57724)).