### PR TITLE
fix: use raw preview URL in order to be able to display external files

### DIFF
--- a/src/views/FileEditView.vue
+++ b/src/views/FileEditView.vue
@@ -261,11 +261,7 @@ onUnmounted(() => {
         md="6"
         class="file-preview fill-height"
       >
-        <iframe
-          v-if="previewURL"
-          id="previewFrame"
-          :src="`${BASE_PATH}${previewURL}`"
-        ></iframe>
+        <iframe v-if="previewURL" id="previewFrame" :src="previewURL"></iframe>
       </v-col>
     </v-row>
   </div>


### PR DESCRIPTION
This takes the entire preview url for the iframe src, in order to be able to point to e.g. externally hosted files.