### PR TITLE
fix: disable `add`/`edit` button when session is `closed`

### DIFF
--- a/src/components/global/Navbar.vue
+++ b/src/components/global/Navbar.vue
@@ -56,6 +56,7 @@ const navPaginationItems = inject("set-nav-pagination-items");
             class="text-capitalize font-weight-medium"
             color="btn-primary"
             v-bind="props"
+            :disabled="navButtonConfig.disabled"
             >{{ navButtonConfig.text }}</v-btn
           >
         </template>

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -65,6 +65,10 @@ const updateDetails = async (cache = false) => {
     cache,
   );
   queryFilesListMethod(fileChanges, { snackbar, fileChangesList, totalPage });
+
+  if (session.value.state !== "closed") {
+    navButtonConfig.value.disabled = false;
+  }
 };
 
 onMounted(async () => {
@@ -93,6 +97,7 @@ onMounted(async () => {
       click: () => suggestion.func?.() || handleAutomationClick(suggestion),
       icon: suggestion.icon || "mdi-auto-fix",
     })),
+    disabled: true,
   };
 
   await updateDetails();


### PR DESCRIPTION
## implementation 
- Disabled `add`/`edit` button when session is `closed` or `merged`