### PR TITLE
fix: prevent premature change event trigger

### DIFF
--- a/src/methods/file-edit-view/file-change.js
+++ b/src/methods/file-edit-view/file-change.js
@@ -20,7 +20,6 @@ export function jsonSchemaFileChangeMethod({
     debouncedPostMessage(message, "*", true);
   } else if (!isEqual(updatedFileContent.value, detail)) {
     updatedFileContent.value = detail;
-    debouncedPostMessage(message, "*");
     updateNavButtonConfig("Save", false);
   } else {
     updateNavButtonConfig("Save", false);
@@ -29,6 +28,7 @@ export function jsonSchemaFileChangeMethod({
   if (isEqual(updatedFileContent.value, fileContent.value))
     updateNavButtonConfig();
 
+  debouncedPostMessage(message, "*");
   hideHiddenFieldsMethod(jsonFormInstance);
 }
 


### PR DESCRIPTION
This prevents reaction to "change" event triggering too soon, as this causes the change detection to misbehave.