### PR TITLE
Fix: Github button text 

### DIFF
--- a/src/components/file/Github.vue
+++ b/src/components/file/Github.vue
@@ -1,22 +1,29 @@
 <script setup>
 import { defineProps } from "vue";
+import Tooltip from "@/components/global/Tooltip.vue";
 const props = defineProps({
   file: {
     type: Object,
     default: {},
   },
+  tooltip: {
+    type: String,
+    default: "View this file on GitHub",
+  },
 });
 </script>
 <template>
-  <v-btn
-    :href="file.html_url"
-    target="_blank"
-    color="blue-grey-darken-4"
-    :icon="$vuetify?.display?.smAndDown ? 'mdi-github' : false"
-    prepend-icon="mdi-github"
-    size="x-large"
-    variant="text"
-    :text="$vuetify?.display?.smAndDown ? '' : 'View on Github'"
-    class="text-capitalize font-weight-medium"
-  ></v-btn>
+  <Tooltip :text="props.tooltip">
+    <v-btn
+      :href="file.html_url"
+      target="_blank"
+      color="blue-grey-darken-4"
+      :icon="$vuetify?.display?.smAndDown ? 'mdi-github' : false"
+      prepend-icon="mdi-github"
+      size="x-large"
+      variant="text"
+      :text="$vuetify?.display?.smAndDown ? '' : 'View File'"
+      class="text-capitalize font-weight-medium"
+    ></v-btn>
+  </Tooltip>
 </template>

--- a/src/components/file/Github.vue
+++ b/src/components/file/Github.vue
@@ -16,7 +16,7 @@ const props = defineProps({
     prepend-icon="mdi-github"
     size="x-large"
     variant="text"
-    :text="$vuetify?.display?.smAndDown ? '' : 'Github'"
+    :text="$vuetify?.display?.smAndDown ? '' : 'View on Github'"
     class="text-capitalize font-weight-medium"
   ></v-btn>
 </template>

--- a/src/components/session/Github.vue
+++ b/src/components/session/Github.vue
@@ -18,7 +18,7 @@ const props = defineProps({
   },
   tooltip: {
     type: String,
-    default: "View Session",
+    default: "View this session on GitHub",
   },
 });
 </script>

--- a/src/components/session/Github.vue
+++ b/src/components/session/Github.vue
@@ -14,11 +14,11 @@ const props = defineProps({
   },
   text: {
     type: String,
-    default: "Github",
+    default: "View Session",
   },
   tooltip: {
     type: String,
-    default: "Open in Github",
+    default: "View Session",
   },
 });
 </script>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/fbdd5206-9248-4f6a-a16f-1016b6917335" width="49%" /> <img src="https://github.com/user-attachments/assets/3c90f14d-f98f-40f2-b4bf-b13938cd0877" width="49%" />

## Implemented changes 
- [x] Changed `Github` button text from `Github` to `View Session` in Session Page
- [x] Changed `Github` button text from `Github` to `View on Github` in File Viewer
