### PR TITLE
chore: change tag names

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  ".": "1.4.1"
+  ".": {
+    "include-component-in-tag": false
+  }
 }


### PR DESCRIPTION
This changes the tag names to not include the package name anymore. By mistake we set it up like a monorepo, with `package-v<version>`. 

The old tags remain, but I will rename the releases to match the new structure.