### PR TITLE
Feat: Automation through outside URL

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -157,8 +157,6 @@ globalThis.automation = [
                 throw new Error("Failed to fetch content from URL");
               }
               content = await response.json();
-              console.log(content);
-              return content;
             } else if (content.match(/^[A-Za-z0-9+/=]+$/)) {
               content = decoderBase64ToUtf8(content);
             }

--- a/src/components/session/Automation.vue
+++ b/src/components/session/Automation.vue
@@ -30,7 +30,9 @@ onMounted(() => {
     initValue.value = Object.fromEntries(
       Object.entries(route.query).filter(([key]) => key !== "automation"),
     );
-    handleAutomationSubmit();
+    setTimeout(() => {
+      handleAutomationSubmit();
+    }, 2000);
   }
   initEOXJSONFormMethod(jsonFormInstance);
 });

--- a/src/components/session/Automation.vue
+++ b/src/components/session/Automation.vue
@@ -3,8 +3,9 @@ import { CUSTOM_EDITOR_INTERFACES } from "@/enums";
 import { initEOXJSONFormMethod } from "@/methods/file-edit-view";
 import { handleAutomationMethod } from "@/methods/session-view";
 import { inject, ref, onMounted } from "vue";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 const snackbar = inject("set-snackbar");
+const route = useRoute();
 const router = useRouter();
 
 const props = defineProps({
@@ -16,6 +17,7 @@ const props = defineProps({
 });
 
 const jsonFormInstance = ref(null);
+const initValue = ref({});
 
 const handleAutomationSubmit = async () => {
   const validate = jsonFormInstance.value.editor.validate();
@@ -24,6 +26,12 @@ const handleAutomationSubmit = async () => {
 };
 
 onMounted(() => {
+  if (route.query.automation && props.selectedAutomation.hidden) {
+    initValue.value = Object.fromEntries(
+      Object.entries(route.query).filter(([key]) => key !== "automation"),
+    );
+    handleAutomationSubmit();
+  }
   initEOXJSONFormMethod(jsonFormInstance);
 });
 </script>
@@ -37,6 +45,7 @@ onMounted(() => {
     <template v-slot:text>
       <eox-jsonform
         id="automation-form"
+        :value="initValue"
         :schema="props.selectedAutomation.inputSchema"
         :customEditorInterfaces="Object.values(CUSTOM_EDITOR_INTERFACES)"
       />

--- a/src/helpers/automation.js
+++ b/src/helpers/automation.js
@@ -29,33 +29,38 @@ export async function runAutomation(props, value, router) {
         loaderEle.textContent,
       );
 
-    if (step.content) {
-      const initialContent =
-        step.content.constructor.name === "AsyncFunction"
-          ? await step.content(value)
-          : step.content(value);
+    if (step.content || step.transform) {
+      let initialContent;
+      let sha;
+
+      if (step.content) {
+        initialContent =
+          step.content.constructor.name === "AsyncFunction"
+            ? await step.content(value)
+            : step.content(value);
+      } else {
+        const fileDetails = await getFileDetails(session, path);
+        const existingContent = parseIfNeeded(
+          decodeString(fileDetails.content),
+        );
+        sha = fileDetails.sha;
+
+        initialContent =
+          step.transform.constructor.name === "AsyncFunction"
+            ? await step.transform(existingContent, value)
+            : step.transform(existingContent, value);
+      }
+
+      if (initialContent instanceof Error) {
+        throw initialContent;
+      }
 
       const content = {
         data: stringifyIfNeeded(initialContent),
         type: "string",
       };
 
-      await createAndUpdateFile(session, path, path, content);
-    } else if (step.transform) {
-      const fileDetails = await getFileDetails(session, path);
-      const existingContent = parseIfNeeded(decodeString(fileDetails.content));
-
-      const transformedContent =
-        step.transform.constructor.name === "AsyncFunction"
-          ? await step.transform(existingContent, value)
-          : step.transform(existingContent, value);
-
-      const content = {
-        data: stringifyIfNeeded(transformedContent),
-        type: "string",
-      };
-
-      await createAndUpdateFile(session, path, path, content, fileDetails.sha);
+      await createAndUpdateFile(session, path, path, content, sha);
     } else if (step.type === "navigate") {
       await new Promise((resolve) => setTimeout(resolve, 1500));
       await router.push(`/${session.number}/${encodeString(path)}`);

--- a/src/helpers/automation.js
+++ b/src/helpers/automation.js
@@ -30,8 +30,13 @@ export async function runAutomation(props, value, router) {
       );
 
     if (step.content) {
+      const initialContent =
+        step.content.constructor.name === "AsyncFunction"
+          ? await step.content(value)
+          : step.content(value);
+
       const content = {
-        data: stringifyIfNeeded(step.content(value)),
+        data: stringifyIfNeeded(initialContent),
         type: "string",
       };
 
@@ -39,7 +44,12 @@ export async function runAutomation(props, value, router) {
     } else if (step.transform) {
       const fileDetails = await getFileDetails(session, path);
       const existingContent = parseIfNeeded(decodeString(fileDetails.content));
-      const transformedContent = step.transform(existingContent, value);
+
+      const transformedContent =
+        step.transform.constructor.name === "AsyncFunction"
+          ? await step.transform(existingContent, value)
+          : step.transform(existingContent, value);
+
       const content = {
         data: stringifyIfNeeded(transformedContent),
         type: "string",

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -21,6 +21,7 @@ import { encodeString, AUTOMATION } from "@/helpers/index.js";
 import { BASE_PATH } from "@/enums";
 import "@eox/jsonform";
 import Automation from "@/components/session/Automation.vue";
+import find from "lodash/find";
 
 const route = useRoute();
 const router = useRouter();
@@ -73,7 +74,7 @@ const updateDetails = async (cache = false) => {
 
 onMounted(async () => {
   suggestionList.value = [
-    ...AUTOMATION,
+    ...AUTOMATION.filter((automation) => !automation.hidden),
     {
       title: "Add/Edit File Manually",
       description:
@@ -99,6 +100,11 @@ onMounted(async () => {
     })),
     disabled: true,
   };
+
+  if (route.query.automation) {
+    const automation = find(AUTOMATION, { id: route.query.automation });
+    if (automation) handleAutomationClick(automation);
+  }
 
   await updateDetails();
 });
@@ -250,7 +256,12 @@ const handleAutomationClose = () => {
   />
 
   <!-- Use the Automation component -->
-  <v-dialog v-model="automationDialog" max-width="500px">
+  <v-dialog
+    v-if="session"
+    :class="selectedAutomation?.hidden ? 'd-none' : ''"
+    v-model="automationDialog"
+    max-width="500px"
+  >
     <Automation
       :handleAutomationClose
       :updateDetails

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -74,7 +74,14 @@ const createFile = async () => {
   loader.value.hide();
 
   if (snackbar.value.number) {
-    setTimeout(() => router.push(`/${snackbar.value.number}`), 750);
+    const params = Object.fromEntries(
+      Object.entries(route.query).filter(([key]) => key !== "session"),
+    );
+    const queryString = new URLSearchParams(params).toString();
+    const url = Boolean(queryString)
+      ? `/${snackbar.value.number}?${queryString}`
+      : `/${snackbar.value.number}`;
+    setTimeout(() => router.push(url), 750);
     clearInputCreateNewSession();
   }
 };
@@ -91,6 +98,11 @@ onMounted(async () => {
     click: createNewSessionClick,
   };
   navPaginationItems.value = [navPaginationItems.value[0]];
+
+  if (route.query.session && route.query.automation) {
+    newSessionName.value = route.query.session;
+    await createFile();
+  }
   await updateSessionsList(true);
 });
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/a863526c-c529-4630-ab72-ea85824492c4


## Implementation 
- Added `automation` through `url`
- Logics can be added to `config.js` - `globalThis.automation`
- Triggered using these params 
  - `session=some-name`
  - `automation=automation-id`
  - `field1=some-field-value-1`
  - `field2=some-field-value-2`
  - etc
- URL path `format` 
```
/?session=Name&automation=automation-id&field1=value-field1&field2=value-field2
```