### PR TITLE
Fix: Toast message when a duplicate fork from same origin account exist

### DIFF
--- a/src/api/session.js
+++ b/src/api/session.js
@@ -54,7 +54,7 @@ export async function createSession(octokit, githubConfig, prName) {
         fork = await octokit.rest.repos.createFork({ owner, repo });
         if (fork.data.name !== repo) {
           throw new Error(
-            "Already a fork from original repo exist in your account.",
+            "A fork of the original repository already exists for your account",
           );
         }
         loaderText.innerText = "Creating fork repo...";

--- a/src/api/session.js
+++ b/src/api/session.js
@@ -52,6 +52,11 @@ export async function createSession(octokit, githubConfig, prName) {
     } catch (error) {
       if (error.status === 404) {
         fork = await octokit.rest.repos.createFork({ owner, repo });
+        if (fork.name !== repo) {
+          throw new Error(
+            "Already a fork from original repo exist in your account.",
+          );
+        }
         loaderText.innerText = "Creating fork repo...";
 
         // Wait for fork creation to be available and try 3 times

--- a/src/api/session.js
+++ b/src/api/session.js
@@ -52,7 +52,7 @@ export async function createSession(octokit, githubConfig, prName) {
     } catch (error) {
       if (error.status === 404) {
         fork = await octokit.rest.repos.createFork({ owner, repo });
-        if (fork.name !== repo) {
+        if (fork.data.name !== repo) {
           throw new Error(
             "Already a fork from original repo exist in your account.",
           );


### PR DESCRIPTION
## Implementation 
- When a duplicate fork is already present in the same origin account, the github API does not allow forking even with the name change. 