### PR TITLE
Feat: Unified all the `globalThis` git clerk related config to `globalThis.gitClerkConfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ As soon as the user starts a new "Session" (PR), a fork for the target repositor
 The configuration for git-clerk is done via the [config file](/public/config.js). In its most basic form, the config looks like this:
 
 ```js
-globalThis.ghConfig = {
+const ghConfig = {
   // The target repository to create PRs against
   githubRepo: "EOX-A/git-clerk-demo",
   // The current user's GH token, either as string or (sync or asyn) function
@@ -25,6 +25,11 @@ globalThis.ghConfig = {
   // Example: githubAuthToken: () => new Promise((resolve) => fetch("<endpoint>").then(() => resolve(token))),
   githubAuthToken: "ghp_myGithubAuthToken",
 };
+
+globalThis.gitClerkConfig = {
+  ghConfig,
+  ...
+}
 ```
 
 You can also set this GitHub config via an `.env` variable, by passing `GITCLERK_GITHUB_TOKEN` and `GITCLERK_GITHUB_REPO` see e.g. [.env.example](./.env.examle).
@@ -38,7 +43,7 @@ With the `schemaMap`, one can configure which file paths are associated with whi
 #### `schema` and `url`
 
 ```js
-globalThis.schemaMap = [
+const schemaMap = [
   {
     path: "/folder-a/file.json",
     schema: {
@@ -57,6 +62,11 @@ globalThis.schemaMap = [
   },
   [...]
 ]
+
+globalThis.gitClerkConfig = {
+  schemaMap,
+  ...
+}
 ```
 
 In this example, editing the file `/folder-a/file.json` loads the corresponding JSON schema passed via the `schema` property, whereas editing a file with the pattern `/folder-a/<id>/file.json` loads the corresponding JSON schema `https://my-schema-site.com/schemas/folder-a/schema.json`.
@@ -66,7 +76,7 @@ In this example, editing the file `/folder-a/file.json` loads the corresponding 
 Additionally to providing a JSON schema, the form can also be autofilled with initial content:
 
 ```js
-globalThis.schemaMap = [
+const schemaMap = [
   {
     path: "/folder-a/file.json",
     schema: {
@@ -84,6 +94,11 @@ globalThis.schemaMap = [
   },
   [...]
 ]
+
+globalThis.gitClerkConfig = {
+  schemaMap,
+  ...
+}
 ```
 
 In this example, the generated form will automatically fill the value "bar" into the `foo` field.
@@ -93,7 +108,7 @@ In this example, the generated form will automatically fill the value "bar" into
 By default, the entire JSON structure is stored (commited) as a JSON file. But one can also specify a specific property which should be stored in the file instead. This is handy when e.g. editing markdown or yaml files:
 
 ```js
-globalThis.schemaMap = [
+const schemaMap = [
   {
     path: "/folder-a/file.md",
     schema: {
@@ -110,6 +125,11 @@ globalThis.schemaMap = [
   },
   [...]
 ]
+
+globalThis.gitClerkConfig = {
+  schemaMap,
+  ...
+}
 ```
 
 In this example, the markdown content of `foo` is commited as file `file.md`.
@@ -125,7 +145,7 @@ An example for this setup can be seen in [here](https://github.com/EOX-A/git-cle
 Sometimes, multiple edits need to be done together (e.g. creating a file in the correct folder structure, putting initial content in that file, and referencing this file in a third file). To make users' lives easier, git-clerk offers automations:
 
 ```js
-globalThis.automation = [
+const automation = [
   {
     title: "Bootstrap Product", // displayed in the UI as button
     description: "Bootstrap a new file with the correct folder structure and ID.", // displayed in the UI as description for this automation
@@ -173,6 +193,11 @@ globalThis.automation = [
   },
   [...]
 ]
+
+globalThis.gitClerkConfig = {
+  automation,
+  ...
+}
 ```
 
 Automations can also be triggered via url query parameters. For this, the automation requires an additional `id` parameter which is referenced by the `automation` query parameter.
@@ -189,7 +214,7 @@ Example:
 Git Clerk uses `eox-jsonform` to render applications based on different JSON editor schemas. `eox-jsonform` contains editor interfaces for each of the primitive JSON types as well as a few other specialized ones. For those who need custom editor interfaces/inputs based on any custom format, they can easily build their own custom editor interface using `JSON Editor`'s `AbstractEditor` class inside `config.js`.
 
 ```js
-globalThis.customEditorInterfaces = {
+const customEditorInterfaces = {
   "some-format-key-name": {
     type: "string", // Any data type for the custom editor
     format: "any-custom-format", // Any custom format key
@@ -197,16 +222,21 @@ globalThis.customEditorInterfaces = {
     ... // Add any key values as per your business logic
   },
 };
+
+globalThis.gitClerkConfig = {
+  customEditorInterfaces,
+  ...
+}
 ```
 
 An example for this setup can be seen in [here](https://github.com/EOX-A/git-clerk/blob/bfa157a499ef488fe3b0ebf3215fb9368d552496/public/config.js#L680).
 
 ### Generate Enums
 
-Sometimes input enums need to be dynamically fetched from an API or other data source to update the schema. `globalThis.generateEnums` inside `config.js` allows users to fetch dynamic enums according to their business logic and then return the updated schema.
+Sometimes input enums need to be dynamically fetched from an API or other data source to update the schema. `globalThis.gitClerkConfig.generateEnums` inside `config.js` allows users to fetch dynamic enums according to their business logic and then return the updated schema.
 
 ```js
-globalThis.generateEnums = async (
+const generateEnums = async (
   schemaMetaDetails,
   session,
   cache,
@@ -214,6 +244,11 @@ globalThis.generateEnums = async (
 ) => {
   ... // Fetch dynamic enums based on the API and update the schemaMetaDetails
   return schemaMetaDetails; // Return the updated schema based on the processing above
+}
+
+globalThis.gitClerkConfig = {
+  generateEnums,
+  ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,17 @@ As soon as the user starts a new "Session" (PR), a fork for the target repositor
 
 ## Configuration
 
-The configuration for git-clerk is done via the [config file](/public/config.js). In its most basic form, the config looks like this:
+The configuration for git-clerk is done via the [config file](/public/config.js) by setting `globalThis.gitClerkConfig`. In its most basic form, the config looks like this:
 
 ```js
-const ghConfig = {
+globalThis.gitClerkConfig = {
   // The target repository to create PRs against
   githubRepo: "EOX-A/git-clerk-demo",
-  // The current user's GH token, either as string or (sync or asyn) function
+  // The current user's GH token, either as string or (sync or async) function
   // Example: githubAuthToken: () => "<github-token>"
   // Example: githubAuthToken: () => new Promise((resolve) => fetch("<endpoint>").then(() => resolve(token))),
   githubAuthToken: "ghp_myGithubAuthToken",
 };
-
-globalThis.gitClerkConfig = {
-  ghConfig,
-  ...
-}
 ```
 
 You can also set this GitHub config via an `.env` variable, by passing `GITCLERK_GITHUB_TOKEN` and `GITCLERK_GITHUB_REPO` see e.g. [.env.example](./.env.examle).
@@ -43,30 +38,29 @@ With the `schemaMap`, one can configure which file paths are associated with whi
 #### `schema` and `url`
 
 ```js
-const schemaMap = [
-  {
-    path: "/folder-a/file.json",
-    schema: {
-      title: "my-schema",
-      type: "object",
-      properties: {
-        foo: {
-          type: "string"
+globalThis.gitClerkConfig = {
+  [...]
+  schemaMap: [
+    {
+      path: "/folder-a/file.json",
+      schema: {
+        title: "my-schema",
+        type: "object",
+        properties: {
+          foo: {
+            type: "string"
+          }
         }
       }
-    }
-  },
-  {
-    path: "/folder-a/<id>/file.json",
-    url: "https://my-schema-site.com/schemas/folder-a/schema.json",
-  },
+    },
+    {
+      path: "/folder-a/<id>/file.json",
+      url: "https://my-schema-site.com/schemas/folder-a/schema.json",
+    },
+    [...]
+  ],
   [...]
-]
-
-globalThis.gitClerkConfig = {
-  schemaMap,
-  ...
-}
+};
 ```
 
 In this example, editing the file `/folder-a/file.json` loads the corresponding JSON schema passed via the `schema` property, whereas editing a file with the pattern `/folder-a/<id>/file.json` loads the corresponding JSON schema `https://my-schema-site.com/schemas/folder-a/schema.json`.
@@ -76,29 +70,28 @@ In this example, editing the file `/folder-a/file.json` loads the corresponding 
 Additionally to providing a JSON schema, the form can also be autofilled with initial content:
 
 ```js
-const schemaMap = [
-  {
-    path: "/folder-a/file.json",
-    schema: {
-      title: "my-schema",
-      type: "object",
-      properties: {
-        foo: {
-          type: "string"
+globalThis.gitClerkConfig = {
+  [...]
+  schemaMap: [
+    {
+      path: "/folder-a/file.json",
+      schema: {
+        title: "my-schema",
+        type: "object",
+        properties: {
+          foo: {
+            type: "string"
+          }
         }
+      },
+      content: {
+        foo: "bar"
       }
     },
-    content: {
-      foo: "bar"
-    }
-  },
+    [...]
+  ],
   [...]
-]
-
-globalThis.gitClerkConfig = {
-  schemaMap,
-  ...
-}
+};
 ```
 
 In this example, the generated form will automatically fill the value "bar" into the `foo` field.
@@ -108,28 +101,27 @@ In this example, the generated form will automatically fill the value "bar" into
 By default, the entire JSON structure is stored (commited) as a JSON file. But one can also specify a specific property which should be stored in the file instead. This is handy when e.g. editing markdown or yaml files:
 
 ```js
-const schemaMap = [
-  {
-    path: "/folder-a/file.md",
-    schema: {
-      title: "my-schema",
-      type: "object",
-      properties: {
-        foo: {
-          type: "string",
-          format: "markdown"
-        }
-      }
-    },
-    output: "foo"
-  },
-  [...]
-]
-
 globalThis.gitClerkConfig = {
-  schemaMap,
-  ...
-}
+  [...]
+  schemaMap: [
+    {
+      path: "/folder-a/file.md",
+      schema: {
+        title: "my-schema",
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+            format: "markdown"
+          }
+        }
+      },
+      output: "foo"
+    },
+    [...]
+  ],
+  [...]
+};
 ```
 
 In this example, the markdown content of `foo` is commited as file `file.md`.
@@ -145,59 +137,58 @@ An example for this setup can be seen in [here](https://github.com/EOX-A/git-cle
 Sometimes, multiple edits need to be done together (e.g. creating a file in the correct folder structure, putting initial content in that file, and referencing this file in a third file). To make users' lives easier, git-clerk offers automations:
 
 ```js
-const automation = [
-  {
-    title: "Bootstrap Product", // displayed in the UI as button
-    description: "Bootstrap a new file with the correct folder structure and ID.", // displayed in the UI as description for this automation
-    inputSchema: { // the input form when the user selects this automation
-      type: "object",
-      properties: {
-        id: {
-          type: "string",
-          minLength: 1
-        },
-        title: {
-          type: "string",
-          minLength: 1
-        }
-      },
-      required: ["id", "title"]
-    },
-    steps: [ // the steps the automation will perform
-      {
-        type: "add", // add a file
-        path: (input) => `/products/${input.id}/collection.json`, // references the above defined form output property "id"
-        content: (input) => ({ id: input.id, title: input.title }) // sets the content of the added file, referencing "id" and "title" from the form
-      },
-      {
-        type: "edit", // edits an existing file
-        path: "/products/catalog.json",
-        transform: (content, input) => { // transforms the content of an existing file
-          content.links = [
-            ...content.links,
-            {
-              rel: "child",
-              href: `./${input.id}/collection.json`,
-              type: "application/json",
-              title: input.title
-            },
-          ]
-          return content
-        }
-      },
-      {
-        type: "navigate", // navigates to the specified file and opens the editing view
-        path: (input) => `/products/${input.id}/collection.json`
-      }
-    ]
-  },
-  [...]
-]
-
 globalThis.gitClerkConfig = {
-  automation,
-  ...
-}
+  [...]
+  automation: [
+    {
+      title: "Bootstrap Product", // displayed in the UI as button
+      description: "Bootstrap a new file with the correct folder structure and ID.", // displayed in the UI as description for this automation
+      inputSchema: { // the input form when the user selects this automation
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            minLength: 1
+          },
+          title: {
+            type: "string",
+            minLength: 1
+          }
+        },
+        required: ["id", "title"]
+      },
+      steps: [ // the steps the automation will perform
+        {
+          type: "add", // add a file
+          path: (input) => `/products/${input.id}/collection.json`, // references the above defined form output property "id"
+          content: (input) => ({ id: input.id, title: input.title }) // sets the content of the added file, referencing "id" and "title" from the form
+        },
+        {
+          type: "edit", // edits an existing file
+          path: "/products/catalog.json",
+          transform: (content, input) => { // transforms the content of an existing file
+            content.links = [
+              ...content.links,
+              {
+                rel: "child",
+                href: `./${input.id}/collection.json`,
+                type: "application/json",
+                title: input.title
+              },
+            ]
+            return content
+          }
+        },
+        {
+          type: "navigate", // navigates to the specified file and opens the editing view
+          path: (input) => `/products/${input.id}/collection.json`
+        }
+      ]
+    },
+    [...]
+  ],
+  [...]
+};
 ```
 
 Automations can also be triggered via url query parameters. For this, the automation requires an additional `id` parameter which is referenced by the `automation` query parameter.
@@ -214,19 +205,18 @@ Example:
 Git Clerk uses `eox-jsonform` to render applications based on different JSON editor schemas. `eox-jsonform` contains editor interfaces for each of the primitive JSON types as well as a few other specialized ones. For those who need custom editor interfaces/inputs based on any custom format, they can easily build their own custom editor interface using `JSON Editor`'s `AbstractEditor` class inside `config.js`.
 
 ```js
-const customEditorInterfaces = {
-  "some-format-key-name": {
-    type: "string", // Any data type for the custom editor
-    format: "any-custom-format", // Any custom format key
-    func: CustomEditorInterface, // Build any custom editor using `JSON Editor`'s `AbstractEditor` class
-    ... // Add any key values as per your business logic
-  },
-};
-
 globalThis.gitClerkConfig = {
-  customEditorInterfaces,
-  ...
-}
+  [...]
+  customEditorInterfaces: {
+    "some-format-key-name": {
+      type: "string", // Any data type for the custom editor
+      format: "any-custom-format", // Any custom format key
+      func: CustomEditorInterface, // Build any custom editor using `JSON Editor`'s `AbstractEditor` class
+      ... // Add any key values as per your business logic
+    },
+  },
+  [...]
+};
 ```
 
 An example for this setup can be seen in [here](https://github.com/EOX-A/git-clerk/blob/bfa157a499ef488fe3b0ebf3215fb9368d552496/public/config.js#L680).
@@ -236,20 +226,19 @@ An example for this setup can be seen in [here](https://github.com/EOX-A/git-cle
 Sometimes input enums need to be dynamically fetched from an API or other data source to update the schema. `globalThis.gitClerkConfig.generateEnums` inside `config.js` allows users to fetch dynamic enums according to their business logic and then return the updated schema.
 
 ```js
-const generateEnums = async (
-  schemaMetaDetails,
-  session,
-  cache,
-  { getFileDetails },
-) => {
-  ... // Fetch dynamic enums based on the API and update the schemaMetaDetails
-  return schemaMetaDetails; // Return the updated schema based on the processing above
-}
-
 globalThis.gitClerkConfig = {
-  generateEnums,
-  ...
-}
+  [...]
+  generateEnums: async (
+    schemaMetaDetails,
+    session,
+    cache,
+    { getFileDetails },
+  ) => {
+    ... // Fetch dynamic enums based on the API and update the schemaMetaDetails
+    return schemaMetaDetails; // Return the updated schema based on the processing above
+  },
+  [...]
+};
 ```
 
 An example for this setup can be seen in [here](https://github.com/EOX-A/git-clerk/blob/bfa157a499ef488fe3b0ebf3215fb9368d552496/public/config.js#L724).
@@ -273,7 +262,7 @@ npm install
 #### Compile and Hot-Reload for Development
 
 ```sh
-npm run dev
+npm start
 ```
 
 #### Compile and Minify for Production

--- a/public/config.js
+++ b/public/config.js
@@ -1,34 +1,12 @@
-import "https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.js";
+/**
+ * Example config file showing all functionalities of git-clerk
+ * It includes all configuration options, plus some helper functions
+ * 
+ * Please refer to README.md for documentation of available configuration options
+ */
 
-function decoderBase64ToUtf8(str) {
-  return decodeURIComponent(escape(atob(str)));
-}
-
-function isBase64(str) {
-  // Regular expression to match base64 pattern
-  const base64Regex =
-    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-
-  try {
-    if (!base64Regex.test(str)) return false;
-
-    const decoded = atob(str);
-    const encoded = btoa(decoded);
-
-    return encoded === str;
-  } catch (err) {
-    return false;
-  }
-}
-
-function isUrl(str) {
-  try {
-    new URL(str);
-    return true;
-  } catch {
-    return false;
-  }
-}
+// Importing JSONEditor.AbstractEditor for Custom editor "MyEditor" (see below)
+import { AbstractEditor } from "https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/src/editor.js/+esm";
 
 // GitHub config
 const ghConfig = {
@@ -167,6 +145,36 @@ const automation = [
           let content = input.content;
           let error = null;
 
+          function decoderBase64ToUtf8(str) {
+            return decodeURIComponent(escape(atob(str)));
+          }
+
+          function isBase64(str) {
+            // Regular expression to match base64 pattern
+            const base64Regex =
+              /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+            try {
+              if (!base64Regex.test(str)) return false;
+
+              const decoded = atob(str);
+              const encoded = btoa(decoded);
+
+              return encoded === str;
+            } catch (err) {
+              return false;
+            }
+          }
+
+          function isUrl(str) {
+            try {
+              new URL(str);
+              return true;
+            } catch {
+              return false;
+            }
+          }
+
           try {
             if (isUrl(content)) {
               const response = await fetch(content);
@@ -197,7 +205,7 @@ const automation = [
 // Custom editor
 // Example of how to build a custom editor can be found here:
 // https://github.com/json-editor/json-editor/blob/master/docs/custom-editor.html
-class MyEditor extends JSONEditor.AbstractEditor {
+class MyEditor extends AbstractEditor {
   register() {
     super.register();
   }

--- a/public/config.js
+++ b/public/config.js
@@ -262,5 +262,5 @@ globalThis.gitClerkConfig = {
   schemaMap,
   automation,
   customEditorInterfaces,
-  generateEnums
+  generateEnums,
 };

--- a/public/config.js
+++ b/public/config.js
@@ -31,16 +31,16 @@ function isUrl(str) {
 }
 
 // GitHub config
-globalThis.ghConfig = {
+const ghConfig = {
   githubRepo: undefined,
   githubAuthToken: undefined,
 };
 
 // Base path at which the apps runs
-globalThis.basePath = "/";
+const basePath = "/";
 
 // Define JSON schemas for specific file paths
-globalThis.schemaMap = [
+const schemaMap = [
   {
     path: "/foo/bar/<id>.json",
     schema: {
@@ -96,7 +96,7 @@ globalThis.schemaMap = [
 ];
 
 // Define automations to perform multiple steps for the user
-globalThis.automation = [
+const automation = [
   {
     title: "Bootstrap File",
     description:
@@ -233,7 +233,7 @@ class MyEditor extends JSONEditor.AbstractEditor {
 }
 
 // Custom editor is used for fields with the format "custom-input"
-globalThis.customEditorInterfaces = {
+const customEditorInterfaces = {
   "custom-input": {
     type: "string",
     format: "custom-input",
@@ -243,7 +243,7 @@ globalThis.customEditorInterfaces = {
 
 // Get file details of file in the same branch and use details of it
 // to populate an enum field
-globalThis.generateEnums = async (
+const generateEnums = async (
   schemaMetaDetails,
   session,
   cache,
@@ -254,4 +254,13 @@ globalThis.generateEnums = async (
     schemaMetaDetails.schema.properties.dynamicEnum.items.enum = [readme.path];
   }
   return schemaMetaDetails;
+};
+
+globalThis.gitClerkConfig = {
+  ghConfig,
+  basePath,
+  schemaMap,
+  automation,
+  customEditorInterfaces,
+  generateEnums
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -18,10 +18,11 @@ import {
   fileDetails,
   schemaFromURL,
 } from "@/api/file";
+import { GIT_CLERK_CONFIG } from "@/enums";
 
 export async function initOctokit() {
   try {
-    const config = globalThis.ghConfig;
+    const config = globalThis.ghConfig || GIT_CLERK_CONFIG.ghConfig;
     let configAuth;
     let configRepo;
 
@@ -54,6 +55,7 @@ export async function initOctokit() {
       ...config,
       config: { auth, username, repo: repoName },
     };
+    globalThis.gitClerkConfig.ghConfig = globalThis.ghConfig;
 
     const octokit = new Octokit({ auth });
 

--- a/src/enums.js
+++ b/src/enums.js
@@ -16,8 +16,15 @@ export const CHECK_STATUS = {
 };
 
 export const GIT_CLERK_CONFIG = globalThis.gitClerkConfig || {};
-export const CUSTOM_EDITOR_INTERFACES = globalThis.customEditorInterfaces || GIT_CLERK_CONFIG.customEditorInterfaces || {};
-export const GENERATE_ENUMS = globalThis.generateEnums || GIT_CLERK_CONFIG.generateEnums;
-export const BASE_PATH = globalThis.basePath || GIT_CLERK_CONFIG.basePath || "/";
-export const SCHEMA_MAP = globalThis.schemaMap || GIT_CLERK_CONFIG.schemaMap || [];
-export const AUTOMATION = globalThis.automation || GIT_CLERK_CONFIG.automation || [];
+export const CUSTOM_EDITOR_INTERFACES =
+  globalThis.customEditorInterfaces ||
+  GIT_CLERK_CONFIG.customEditorInterfaces ||
+  {};
+export const GENERATE_ENUMS =
+  globalThis.generateEnums || GIT_CLERK_CONFIG.generateEnums;
+export const BASE_PATH =
+  globalThis.basePath || GIT_CLERK_CONFIG.basePath || "/";
+export const SCHEMA_MAP =
+  globalThis.schemaMap || GIT_CLERK_CONFIG.schemaMap || [];
+export const AUTOMATION =
+  globalThis.automation || GIT_CLERK_CONFIG.automation || [];

--- a/src/enums.js
+++ b/src/enums.js
@@ -15,6 +15,9 @@ export const CHECK_STATUS = {
   },
 };
 
-export const CUSTOM_EDITOR_INTERFACES = globalThis.customEditorInterfaces || {};
-export const GENERATE_ENUMS = globalThis.generateEnums;
-export const BASE_PATH = globalThis.basePath || "/";
+export const GIT_CLERK_CONFIG = globalThis.gitClerkConfig || {};
+export const CUSTOM_EDITOR_INTERFACES = globalThis.customEditorInterfaces || GIT_CLERK_CONFIG.customEditorInterfaces || {};
+export const GENERATE_ENUMS = globalThis.generateEnums || GIT_CLERK_CONFIG.generateEnums;
+export const BASE_PATH = globalThis.basePath || GIT_CLERK_CONFIG.basePath || "/";
+export const SCHEMA_MAP = globalThis.schemaMap || GIT_CLERK_CONFIG.schemaMap || [];
+export const AUTOMATION = globalThis.automation || GIT_CLERK_CONFIG.automation || [];

--- a/src/helpers/automation.js
+++ b/src/helpers/automation.js
@@ -6,7 +6,6 @@ import {
 } from "@/helpers";
 import { createAndUpdateFile, getFileDetails } from "@/api";
 
-export const AUTOMATION = globalThis.automation || [];
 const getLoaderMsg = (type, path, currentMsg) => {
   const messages = {
     add: "Creating File",

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -10,4 +10,4 @@ export { default as isValidFormJSON } from "./is-valid-form-json";
 export { default as updateSchemaDefaults } from "./update-schema-default";
 export { getSchemaDetails, getFileSchema } from "./schema";
 export { stringifyIfNeeded, parseIfNeeded } from "./transform";
-export { AUTOMATION, runAutomation } from "./automation";
+export { runAutomation } from "./automation";

--- a/src/helpers/schema.js
+++ b/src/helpers/schema.js
@@ -1,4 +1,4 @@
-export const SCHEMA_MAP = globalThis.schemaMap || [];
+import { SCHEMA_MAP } from "@/enums";
 
 export function getSchemaDetails(inputPath) {
   for (const schema of SCHEMA_MAP) {

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -17,8 +17,8 @@ import {
   FileUploader,
   DuplicateFile,
 } from "@/components/file";
-import { encodeString, AUTOMATION } from "@/helpers/index.js";
-import { BASE_PATH } from "@/enums";
+import { encodeString } from "@/helpers/index.js";
+import { BASE_PATH, AUTOMATION } from "@/enums";
 import "@eox/jsonform";
 import Automation from "@/components/session/Automation.vue";
 import find from "lodash/find";


### PR DESCRIPTION
## Implementation 
- Unified all the `globalThis` git clerk related config to `globalThis.gitClerkConfig` and can be accessed as `globalThis.gitClerkConfig.ghConfig`

```js
globalThis.gitClerkConfig = {
  ghConfig,
  basePath,
  schemaMap,
  automation,
  customEditorInterfaces,
  generateEnums,
};
```

- Previously used individual `config` can also be assigned like `globalThis.ghConfig`