### PR TITLE
Feat: Support preview deployment link 

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,23 @@ globalThis.gitClerkConfig = {
 
 An example for this setup can be seen in [here](https://github.com/EOX-A/git-clerk/blob/bfa157a499ef488fe3b0ebf3215fb9368d552496/public/config.js#L724).
 
+### Deployed Preview Link
+
+Git Clerk allows you to configure a custom preview link for your sessions/PRs. This can be useful if you have preview deployments set up for your sessions. You can configure this by adding a `deployedPreviewLink` function to your config that returns the preview URL:
+
+```js
+globalThis.gitClerkConfig = {
+  [...]
+  deployedPreviewLink: (sessionDetail) => {
+    const { number } = sessionDetail;
+    return `https://deploy-preview-url.com/${number}/preview.html`;
+  }
+  [...]
+};
+```
+
+An example for this setup can be seen in [here](https://github.com/EOX-A/git-clerk/blob/31bf8b16b5749f55c072bedd16e5eb68ae715f15/public/config.js#L267).
+
 ## Development
 
 ### Recommended IDE Setup

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,6 +5,8 @@ export default defineConfig({
     baseUrl: "http://localhost:3000",
     projectId: "git-clerk",
     testIsolation: false,
+    viewportWidth: 1366,
+    viewportHeight: 768,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/files-list.cy.js
+++ b/cypress/e2e/files-list.cy.js
@@ -301,4 +301,18 @@ describe("Files list related tests", () => {
       .find(".main-title")
       .should("have.text", "hello/code.js");
   });
+
+  // Test to check if deployed preview link exists
+  it("Check preview link exists", () => {
+    cy.window().then((win) => {
+      expect(win.gitClerkConfig).to.exist;
+      cy.get("#deployed-preview-btn").should(($btn) => {
+        if (win.gitClerkConfig.deployedPreviewLink)
+          expect($btn.attr("href")).to.equal(
+            win.gitClerkConfig.deployedPreviewLink(pullsData),
+          );
+        else expect($btn).to.not.exist;
+      });
+    });
+  });
 });

--- a/cypress/e2e/files-list.cy.js
+++ b/cypress/e2e/files-list.cy.js
@@ -150,6 +150,7 @@ describe("Files list related tests", () => {
 
   it("Rename session", () => {
     sessionName = true;
+    cy.get("#session-action-menu").click();
     cy.get("#rename-session-btn").click();
     cy.get(".rename-session-container .v-field__input")
       .clear()
@@ -196,6 +197,7 @@ describe("Files list related tests", () => {
   // Test file deletion functionality
   it("Delete a file", () => {
     cy.wait("@getFiles");
+    cy.get("#session-action-menu").click();
     cy.get(".files-view")
       .eq(files.length - 1)
       .find(".v-btn .mdi-delete-outline")

--- a/public/config.js
+++ b/public/config.js
@@ -1,7 +1,7 @@
 /**
  * Example config file showing all functionalities of git-clerk
  * It includes all configuration options, plus some helper functions
- * 
+ *
  * Please refer to README.md for documentation of available configuration options
  */
 
@@ -264,6 +264,11 @@ const generateEnums = async (
   return schemaMetaDetails;
 };
 
+const deployedPreviewLink = (sessionDetail) => {
+  const { number, base } = sessionDetail;
+  return `https://github.com/${base.repo.owner.login}/${base.repo.name}/pull/${number}`;
+};
+
 globalThis.gitClerkConfig = {
   ghConfig,
   basePath,
@@ -271,4 +276,5 @@ globalThis.gitClerkConfig = {
   automation,
   customEditorInterfaces,
   generateEnums,
+  deployedPreviewLink,
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -106,9 +106,9 @@ export async function reviewBySessionNumber(sessionNumber, pullRequestId) {
   return reviewSession(octokit, githubConfig, sessionNumber, pullRequestId);
 }
 
-export async function getCheckStatus(sessionNumber) {
+export async function getCheckStatus(sha) {
   const { githubConfig, octokit } = useOctokitStore();
-  return checkStatus(octokit, githubConfig, sessionNumber);
+  return checkStatus(octokit, githubConfig, sha);
 }
 
 export async function getSessionReviewStatus(sessionNumber) {

--- a/src/api/session.js
+++ b/src/api/session.js
@@ -267,18 +267,8 @@ export async function reviewSession(
   }
 }
 
-export async function checkStatus(octokit, githubConfig, sessionNumber) {
+export async function checkStatus(octokit, githubConfig, sha) {
   try {
-    const {
-      data: {
-        head: { sha },
-      },
-    } = await octokit.rest.pulls.get({
-      owner: githubConfig.username,
-      repo: githubConfig.repo,
-      pull_number: sessionNumber,
-    });
-
     const response = await octokit.rest.checks.listForRef({
       owner: githubConfig.username,
       repo: githubConfig.repo,

--- a/src/components/file/ActionTabFileList.vue
+++ b/src/components/file/ActionTabFileList.vue
@@ -22,7 +22,7 @@ const props = defineProps({
 <template>
   <div
     v-if="session"
-    class="bg-surface-light px-0 px-sm-5 py-4 d-flex align-center ga-1 action-tab position-relative"
+    class="bg-surface-light px-0 px-sm-5 py-4 d-flex align-center ga-2 action-tab position-relative"
     :class="{ 'flex-row-reverse': $vuetify?.display?.smAndDown }"
   >
     <GithubSession :url="props.session.html_url" tab size="x-large" />
@@ -70,6 +70,19 @@ const props = defineProps({
       :callBack="props.updateDetails"
       class="ml-5"
     />
+
+    <v-btn
+      v-if="session.deployedPreviewLink"
+      target="_blank"
+      variant="outlined"
+      color="black"
+      prepend-icon="mdi-arrow-top-right"
+      size="x-large"
+      :href="session.deployedPreviewLink"
+      class="border-black border-md border-opacity-100"
+    >
+      Deployed Preview
+    </v-btn>
     <v-spacer></v-spacer>
     <v-chip
       class="mx-5 pl-5 session-icon ga-2"

--- a/src/components/file/ActionTabFileList.vue
+++ b/src/components/file/ActionTabFileList.vue
@@ -4,6 +4,7 @@ import {
   ReviewSession,
   GithubSession,
   RenameSession,
+  DeployedPreview,
 } from "@/components/session/index.js";
 import { defineProps, inject } from "vue";
 import OctIcon from "@/components/global/OctIcon.vue";
@@ -70,19 +71,11 @@ const props = defineProps({
       :callBack="props.updateDetails"
       class="ml-5"
     />
-
-    <v-btn
-      v-if="session.deployedPreviewLink"
-      target="_blank"
-      variant="outlined"
-      color="black"
-      prepend-icon="mdi-arrow-top-right"
+    <DeployedPreview
+      :url="props.session.deployedPreviewLink"
+      tab
       size="x-large"
-      :href="session.deployedPreviewLink"
-      class="border-black border-md border-opacity-100"
-    >
-      Deployed Preview
-    </v-btn>
+    />
     <v-spacer></v-spacer>
     <v-chip
       class="mx-5 pl-5 session-icon ga-2"

--- a/src/components/file/index.js
+++ b/src/components/file/index.js
@@ -1,5 +1,4 @@
 export { default as DeleteFile } from "./Delete.vue";
-export { default as ActionTabFileList } from "./ActionTabFileList.vue";
 export { default as ActionTabFileEditor } from "./ActionTabFileEditor.vue";
 export { default as CreateFile } from "./CreateFile.vue";
 export { default as FileUploader } from "./FileUploader.vue";

--- a/src/components/session/ActionSessions.vue
+++ b/src/components/session/ActionSessions.vue
@@ -11,7 +11,7 @@ const props = defineProps({
     type: Object,
     default: {},
   },
-  updateDetails: Function,
+  callBack: Function,
 });
 </script>
 
@@ -21,12 +21,12 @@ const props = defineProps({
     tab
     size="x-large"
     :session="props.session"
-    :callBack="props.updateDetails"
+    :callBack="props.callBack"
   />
   <RenameSession
     tab
     size="x-large"
     :session="props.session"
-    :callBack="props.updateDetails"
+    :callBack="props.callBack"
   />
 </template>

--- a/src/components/session/ActionSessions.vue
+++ b/src/components/session/ActionSessions.vue
@@ -1,0 +1,32 @@
+<script setup>
+import {
+  DeleteSession,
+  RenameSession,
+  GithubSession,
+} from "@/components/session/index.js";
+import { defineProps } from "vue";
+
+const props = defineProps({
+  session: {
+    type: Object,
+    default: {},
+  },
+  updateDetails: Function,
+});
+</script>
+
+<template>
+  <GithubSession :url="props.session.html_url" tab size="x-large" />
+  <DeleteSession
+    tab
+    size="x-large"
+    :session="props.session"
+    :callBack="props.updateDetails"
+  />
+  <RenameSession
+    tab
+    size="x-large"
+    :session="props.session"
+    :callBack="props.updateDetails"
+  />
+</template>

--- a/src/components/session/ActionTabSession.vue
+++ b/src/components/session/ActionTabSession.vue
@@ -1,15 +1,15 @@
 <script setup>
 import {
-  DeleteSession,
   ReviewSession,
-  GithubSession,
-  RenameSession,
   DeployedPreview,
+  ActionSessions,
 } from "@/components/session/index.js";
-import { defineProps, inject } from "vue";
+import { defineProps, inject, computed } from "vue";
+import { useDisplay } from "vuetify";
 import OctIcon from "@/components/global/OctIcon.vue";
 
 const snackbar = inject("set-snackbar");
+const { width } = useDisplay();
 
 const props = defineProps({
   session: {
@@ -18,24 +18,37 @@ const props = defineProps({
   },
   updateDetails: Function,
 });
+
+const enableSessionActionList = computed(() => {
+  return width.value <= 1440;
+});
 </script>
 
 <template>
   <div
     v-if="session"
     class="bg-surface-light px-0 px-sm-5 py-4 d-flex align-center ga-2 action-tab position-relative"
-    :class="{ 'flex-row-reverse': $vuetify?.display?.smAndDown }"
   >
-    <GithubSession :url="props.session.html_url" tab size="x-large" />
-    <DeleteSession
-      tab
-      size="x-large"
-      :session="props.session"
-      :callBack="props.updateDetails"
-    />
-    <RenameSession
-      tab
-      size="x-large"
+    <v-menu v-if="enableSessionActionList" :close-on-content-click="false">
+      <template v-slot:activator="{ props }">
+        <v-btn
+          v-bind="props"
+          prepend-icon="mdi-dots-vertical"
+          variant="text"
+          size="x-large"
+          text="Sessions"
+          color="blue-grey-darken-4"
+        ></v-btn>
+      </template>
+      <v-list>
+        <ActionSessions
+          :session="props.session"
+          :callBack="props.updateDetails"
+        />
+      </v-list>
+    </v-menu>
+    <ActionSessions
+      v-else
       :session="props.session"
       :callBack="props.updateDetails"
     />
@@ -43,12 +56,14 @@ const props = defineProps({
       v-if="props.session.state !== 'closed'"
       inset
       vertical
-      class="d-none d-sm-flex"
     ></v-divider>
     <v-btn
       v-if="!props.session.draft && props.session.state !== 'closed'"
       target="_blank"
       color="primary"
+      :icon="
+        $vuetify.display.mdAndUp ? false : 'mdi-dots-horizontal-circle-outline'
+      "
       prepend-icon="mdi-dots-horizontal-circle-outline"
       size="x-large"
       variant="flat"
@@ -78,7 +93,7 @@ const props = defineProps({
     />
     <v-spacer></v-spacer>
     <v-chip
-      class="mx-5 pl-5 session-icon ga-2"
+      class="mx-5 pl-5 session-icon ga-2 d-sm-flex d-none"
       size="large"
       label
       :color="session.status.color"

--- a/src/components/session/ActionTabSession.vue
+++ b/src/components/session/ActionTabSession.vue
@@ -20,7 +20,7 @@ const props = defineProps({
 });
 
 const enableSessionActionList = computed(() => {
-  return width.value <= 1440;
+  return width.value <= 1280;
 });
 </script>
 

--- a/src/components/session/ActionTabSession.vue
+++ b/src/components/session/ActionTabSession.vue
@@ -87,6 +87,7 @@ const enableSessionActionList = computed(() => {
       class="ml-5"
     />
     <DeployedPreview
+      v-if="props.session.deployedPreviewLink"
       :url="props.session.deployedPreviewLink"
       tab
       size="x-large"

--- a/src/components/session/ActionTabSession.vue
+++ b/src/components/session/ActionTabSession.vue
@@ -34,7 +34,7 @@ const props = defineProps({
           id="session-action-menu"
         ></v-btn>
       </template>
-      <v-list>
+      <v-list class="pa-0">
         <ActionSessions
           :session="props.session"
           :callBack="props.updateDetails"
@@ -68,8 +68,8 @@ const props = defineProps({
       class="ml-5"
     />
     <DeployedPreview
-      :url="props.session.deployedPreviewLink"
-      :files="props.session.changed_files"
+      v-if="props.session.deployedPreviewLink"
+      :session="props.session"
       :state="props.session.state"
       tab
       size="x-large"

--- a/src/components/session/ActionTabSession.vue
+++ b/src/components/session/ActionTabSession.vue
@@ -31,6 +31,7 @@ const props = defineProps({
           size="x-large"
           text="Session"
           color="blue-grey-darken-4"
+          id="session-action-menu"
         ></v-btn>
       </template>
       <v-list>

--- a/src/components/session/ActionTabSession.vue
+++ b/src/components/session/ActionTabSession.vue
@@ -4,12 +4,8 @@ import {
   DeployedPreview,
   ActionSessions,
 } from "@/components/session/index.js";
-import { defineProps, inject, computed } from "vue";
-import { useDisplay } from "vuetify";
+import { defineProps } from "vue";
 import OctIcon from "@/components/global/OctIcon.vue";
-
-const snackbar = inject("set-snackbar");
-const { width } = useDisplay();
 
 const props = defineProps({
   session: {
@@ -18,10 +14,6 @@ const props = defineProps({
   },
   updateDetails: Function,
 });
-
-const enableSessionActionList = computed(() => {
-  return width.value <= 1280;
-});
 </script>
 
 <template>
@@ -29,14 +21,15 @@ const enableSessionActionList = computed(() => {
     v-if="session"
     class="bg-surface-light px-0 px-sm-5 py-4 d-flex align-center ga-2 action-tab position-relative"
   >
-    <v-menu v-if="enableSessionActionList" :close-on-content-click="false">
+    <v-menu :close-on-content-click="false">
       <template v-slot:activator="{ props }">
         <v-btn
           v-bind="props"
           prepend-icon="mdi-dots-vertical"
+          append-icon="mdi-chevron-down"
           variant="text"
           size="x-large"
-          text="Sessions"
+          text="Session"
           color="blue-grey-darken-4"
         ></v-btn>
       </template>
@@ -47,16 +40,7 @@ const enableSessionActionList = computed(() => {
         />
       </v-list>
     </v-menu>
-    <ActionSessions
-      v-else
-      :session="props.session"
-      :callBack="props.updateDetails"
-    />
-    <v-divider
-      v-if="props.session.state !== 'closed'"
-      inset
-      vertical
-    ></v-divider>
+    <v-divider inset vertical></v-divider>
     <v-btn
       v-if="!props.session.draft && props.session.state !== 'closed'"
       target="_blank"
@@ -72,11 +56,7 @@ const enableSessionActionList = computed(() => {
       disabled
     ></v-btn>
     <ReviewSession
-      v-else-if="
-        props.session.draft &&
-        props.session.check &&
-        props.session.state !== 'closed'
-      "
+      v-else-if="props.session.draft && props.session.check"
       tab
       text="Submit for Review"
       size="x-large"
@@ -87,8 +67,9 @@ const enableSessionActionList = computed(() => {
       class="ml-5"
     />
     <DeployedPreview
-      v-if="props.session.deployedPreviewLink"
       :url="props.session.deployedPreviewLink"
+      :files="props.session.changed_files"
+      :state="props.session.state"
       tab
       size="x-large"
     />

--- a/src/components/session/Delete.vue
+++ b/src/components/session/Delete.vue
@@ -41,18 +41,6 @@ const disabled = props.session.state === "closed";
 
 <template>
   <!-- Tab = true -->
-  <!-- Mobile -->
-  <v-btn
-    v-if="tab"
-    color="blue-grey-darken-4"
-    icon="mdi-delete-outline"
-    :size="size"
-    variant="text"
-    :disabled="disabled"
-    @click="deleteSession = session"
-    class="d-flex d-sm-none"
-  ></v-btn>
-  <!-- Non-mobile -->
   <v-btn
     v-if="tab"
     color="blue-grey-darken-4"
@@ -62,7 +50,7 @@ const disabled = props.session.state === "closed";
     variant="text"
     :disabled="disabled"
     @click="deleteSession = session"
-    class="text-capitalize font-weight-medium d-none d-sm-flex"
+    class="text-capitalize font-weight-medium d-flex"
   ></v-btn>
 
   <!-- Tab = false -->

--- a/src/components/session/Delete.vue
+++ b/src/components/session/Delete.vue
@@ -43,6 +43,8 @@ const disabled = props.session.state === "closed";
   <!-- Tab = true -->
   <v-btn
     v-if="tab"
+    rounded="0"
+    block
     color="blue-grey-darken-4"
     prepend-icon="mdi-delete-outline"
     :size="size"
@@ -50,7 +52,7 @@ const disabled = props.session.state === "closed";
     variant="text"
     :disabled="disabled"
     @click="deleteSession = session"
-    class="text-capitalize font-weight-medium d-flex"
+    class="text-capitalize font-weight-medium d-flex justify-start"
   ></v-btn>
 
   <!-- Tab = false -->

--- a/src/components/session/DeployedPreview.vue
+++ b/src/components/session/DeployedPreview.vue
@@ -33,8 +33,8 @@ const props = defineProps({
     color="blue-grey-darken-4"
     icon="mdi-arrow-top-right"
     :size="size"
-    variant="text"
-    class="d-flex d-sm-none"
+    variant="outlined"
+    class="d-flex d-md-none border-black border-md border-opacity-100"
   ></v-btn>
   <!-- Non-mobile -->
   <v-btn
@@ -46,7 +46,7 @@ const props = defineProps({
     :size="size"
     :text="text"
     variant="outlined"
-    class="text-capitalize font-weight-medium d-none d-sm-flex border-black border-md border-opacity-100"
+    class="text-capitalize font-weight-medium d-none d-md-flex border-black border-md border-opacity-100"
   ></v-btn>
 
   <!-- Tab = false -->

--- a/src/components/session/DeployedPreview.vue
+++ b/src/components/session/DeployedPreview.vue
@@ -1,0 +1,75 @@
+<script setup>
+import { defineProps } from "vue";
+import Tooltip from "@/components/global/Tooltip.vue";
+
+const props = defineProps({
+  url: String,
+  tab: {
+    type: Boolean,
+    default: false,
+  },
+  size: {
+    type: String,
+    default: "large",
+  },
+  text: {
+    type: String,
+    default: "Deployed Preview",
+  },
+  tooltip: {
+    type: String,
+    default: "View deployed preview",
+  },
+});
+</script>
+
+<template>
+  <!-- Tab = true -->
+  <!-- Mobile -->
+  <v-btn
+    v-if="tab"
+    :href="url"
+    target="_blank"
+    color="blue-grey-darken-4"
+    icon="mdi-arrow-top-right"
+    :size="size"
+    variant="text"
+    class="d-flex d-sm-none"
+  ></v-btn>
+  <!-- Non-mobile -->
+  <v-btn
+    v-if="tab"
+    :href="url"
+    target="_blank"
+    color="blue-grey-darken-4"
+    prepend-icon="mdi-arrow-top-right"
+    :size="size"
+    :text="text"
+    variant="outlined"
+    class="text-capitalize font-weight-medium d-none d-sm-flex border-black border-md border-opacity-100"
+  ></v-btn>
+
+  <!-- Tab = false -->
+  <!-- Mobile -->
+  <v-list-item
+    v-if="!tab"
+    :href="url"
+    target="_blank"
+    prepend-icon="mdi-arrow-top-right"
+    :title="props.tooltip"
+    class="d-flex d-sm-none"
+  ></v-list-item>
+  <!-- Non-mobile -->
+  <Tooltip :text="props.tooltip">
+    <v-btn
+      v-if="!tab"
+      :href="url"
+      target="_blank"
+      color="blue-grey-darken-4"
+      icon="mdi-arrow-top-right"
+      :size="size"
+      variant="text"
+      class="d-none d-sm-flex"
+    ></v-btn>
+  </Tooltip>
+</template>

--- a/src/components/session/DeployedPreview.vue
+++ b/src/components/session/DeployedPreview.vue
@@ -35,6 +35,7 @@ const props = defineProps({
     :size="size"
     variant="outlined"
     class="d-flex d-md-none border-black border-md border-opacity-100"
+    id="deployed-preview-btn"
   ></v-btn>
   <!-- Non-mobile -->
   <v-btn
@@ -47,6 +48,7 @@ const props = defineProps({
     :text="text"
     variant="outlined"
     class="text-capitalize font-weight-medium d-none d-md-flex border-black border-md border-opacity-100"
+    id="deployed-preview-btn"
   ></v-btn>
 
   <!-- Tab = false -->
@@ -58,6 +60,7 @@ const props = defineProps({
     prepend-icon="mdi-arrow-top-right"
     :title="props.tooltip"
     class="d-flex d-sm-none"
+    id="deployed-preview-btn"
   ></v-list-item>
   <!-- Non-mobile -->
   <Tooltip :text="props.tooltip">
@@ -70,6 +73,7 @@ const props = defineProps({
       :size="size"
       variant="text"
       class="d-none d-sm-flex"
+      id="deployed-preview-btn"
     ></v-btn>
   </Tooltip>
 </template>

--- a/src/components/session/DeployedPreview.vue
+++ b/src/components/session/DeployedPreview.vue
@@ -2,10 +2,9 @@
 import { defineProps, ref, watch } from "vue";
 
 const props = defineProps({
-  url: String,
-  files: {
-    type: Number,
-    default: 0,
+  session: {
+    type: Object,
+    default: {},
   },
   state: {
     type: String,
@@ -33,7 +32,10 @@ const disabled = ref(checkDisableStatus(props));
 
 function checkDisableStatus(newProps) {
   return Boolean(
-    newProps.files === 0 || !newProps.url || newProps.state === "closed",
+    newProps.session.changed_files === 0 ||
+      newProps.session.commits < 2 ||
+      !newProps.session.deployedPreviewLink ||
+      newProps.state === "closed",
   );
 }
 
@@ -46,7 +48,7 @@ watch([props], ([newProps]) => {
   <!-- Mobile -->
   <v-btn
     v-if="tab"
-    :href="url"
+    :href="session.deployedPreviewLink"
     target="_blank"
     color="blue-grey-darken-4"
     icon="mdi-arrow-top-right"
@@ -59,7 +61,7 @@ watch([props], ([newProps]) => {
   <!-- Non-mobile -->
   <v-btn
     v-if="tab"
-    :href="url"
+    :href="session.deployedPreviewLink"
     target="_blank"
     color="blue-grey-darken-4"
     prepend-icon="mdi-arrow-top-right"

--- a/src/components/session/DeployedPreview.vue
+++ b/src/components/session/DeployedPreview.vue
@@ -1,9 +1,16 @@
 <script setup>
-import { defineProps } from "vue";
-import Tooltip from "@/components/global/Tooltip.vue";
+import { defineProps, ref, watch } from "vue";
 
 const props = defineProps({
   url: String,
+  files: {
+    type: Number,
+    default: 0,
+  },
+  state: {
+    type: String,
+    default: "open",
+  },
   tab: {
     type: Boolean,
     default: false,
@@ -21,10 +28,21 @@ const props = defineProps({
     default: "View deployed preview",
   },
 });
+
+const disabled = ref(checkDisableStatus(props));
+
+function checkDisableStatus(newProps) {
+  return Boolean(
+    newProps.files === 0 || !newProps.url || newProps.state === "closed",
+  );
+}
+
+watch([props], ([newProps]) => {
+  disabled.value = checkDisableStatus(newProps);
+});
 </script>
 
 <template>
-  <!-- Tab = true -->
   <!-- Mobile -->
   <v-btn
     v-if="tab"
@@ -36,6 +54,7 @@ const props = defineProps({
     variant="outlined"
     class="d-flex d-md-none border-black border-md border-opacity-100"
     id="deployed-preview-btn"
+    :disabled="disabled"
   ></v-btn>
   <!-- Non-mobile -->
   <v-btn
@@ -49,31 +68,6 @@ const props = defineProps({
     variant="outlined"
     class="text-capitalize font-weight-medium d-none d-md-flex border-black border-md border-opacity-100"
     id="deployed-preview-btn"
+    :disabled="disabled"
   ></v-btn>
-
-  <!-- Tab = false -->
-  <!-- Mobile -->
-  <v-list-item
-    v-if="!tab"
-    :href="url"
-    target="_blank"
-    prepend-icon="mdi-arrow-top-right"
-    :title="props.tooltip"
-    class="d-flex d-sm-none"
-    id="deployed-preview-btn"
-  ></v-list-item>
-  <!-- Non-mobile -->
-  <Tooltip :text="props.tooltip">
-    <v-btn
-      v-if="!tab"
-      :href="url"
-      target="_blank"
-      color="blue-grey-darken-4"
-      icon="mdi-arrow-top-right"
-      :size="size"
-      variant="text"
-      class="d-none d-sm-flex"
-      id="deployed-preview-btn"
-    ></v-btn>
-  </Tooltip>
 </template>

--- a/src/components/session/Github.vue
+++ b/src/components/session/Github.vue
@@ -28,6 +28,8 @@ const props = defineProps({
   <!-- Non-mobile -->
   <v-btn
     v-if="tab"
+    rounded="0"
+    block
     :href="url"
     target="_blank"
     color="blue-grey-darken-4"
@@ -35,7 +37,7 @@ const props = defineProps({
     :size="size"
     :text="text"
     variant="text"
-    class="text-capitalize font-weight-medium d-flex"
+    class="text-capitalize font-weight-medium d-flex justify-start"
   ></v-btn>
 
   <!-- Tab = false -->

--- a/src/components/session/Github.vue
+++ b/src/components/session/Github.vue
@@ -25,17 +25,6 @@ const props = defineProps({
 
 <template>
   <!-- Tab = true -->
-  <!-- Mobile -->
-  <v-btn
-    v-if="tab"
-    :href="url"
-    target="_blank"
-    color="blue-grey-darken-4"
-    icon="mdi-github"
-    :size="size"
-    variant="text"
-    class="d-flex d-sm-none"
-  ></v-btn>
   <!-- Non-mobile -->
   <v-btn
     v-if="tab"
@@ -46,7 +35,7 @@ const props = defineProps({
     :size="size"
     :text="text"
     variant="text"
-    class="text-capitalize font-weight-medium d-none d-sm-flex"
+    class="text-capitalize font-weight-medium d-flex"
   ></v-btn>
 
   <!-- Tab = false -->

--- a/src/components/session/Rename.vue
+++ b/src/components/session/Rename.vue
@@ -54,17 +54,6 @@ const closeRename = () => {
 
 <template>
   <!-- Tab = true -->
-  <!-- Mobile -->
-  <v-btn
-    v-if="tab"
-    color="blue-grey-darken-4"
-    icon="mdi-pencil-outline"
-    :size="size"
-    variant="text"
-    :disabled="disabled"
-    @click="renameSession = session"
-    class="d-flex d-sm-none"
-  ></v-btn>
   <!-- Non-mobile -->
   <v-btn
     v-if="tab"
@@ -75,7 +64,7 @@ const closeRename = () => {
     variant="text"
     :disabled="disabled"
     @click="renameSession = session"
-    class="text-capitalize font-weight-medium d-none d-sm-flex"
+    class="text-capitalize font-weight-medium d-flex"
     id="rename-session-btn"
   ></v-btn>
 

--- a/src/components/session/Rename.vue
+++ b/src/components/session/Rename.vue
@@ -57,6 +57,8 @@ const closeRename = () => {
   <!-- Non-mobile -->
   <v-btn
     v-if="tab"
+    rounded="0"
+    block
     color="blue-grey-darken-4"
     prepend-icon="mdi-pencil-outline"
     :size="size"
@@ -64,7 +66,7 @@ const closeRename = () => {
     variant="text"
     :disabled="disabled"
     @click="renameSession = session"
-    class="text-capitalize font-weight-medium d-flex"
+    class="text-capitalize font-weight-medium d-flex justify-start"
     id="rename-session-btn"
   ></v-btn>
 

--- a/src/components/session/Review.vue
+++ b/src/components/session/Review.vue
@@ -61,7 +61,7 @@ const reviewSessionHandle = async () => {
 };
 
 function checkDisableStatus(newProps) {
-  if (!newProps.session) return true;
+  if (!newProps.session || newProps.session.changed_files === 0) return true;
   return (
     !newProps.session.draft ||
     newProps.session.state === "closed" ||

--- a/src/components/session/Review.vue
+++ b/src/components/session/Review.vue
@@ -86,14 +86,14 @@ watch([props], ([newProps]) => {
   >
     <v-btn
       :color="props.color"
-      :icon="props.tab ? false : 'mdi-file-document-edit'"
+      :icon="$vuetify.display.mdAndUp ? false : 'mdi-file-document-edit'"
       prepend-icon="mdi-file-document-edit"
       :size="props.size"
       :text="props.text"
       :variant="props.variant"
       :disabled="disabled"
       @click="reviewSession = props.session"
-      :class="`text-capitalize font-weight-medium ${props.class} d-none d-sm-flex`"
+      :class="`text-capitalize font-weight-medium ${props.class}`"
     >
       <template v-if="error" v-slot:append>
         <v-icon

--- a/src/components/session/index.js
+++ b/src/components/session/index.js
@@ -3,3 +3,4 @@ export { default as ReviewSession } from "./Review.vue";
 export { default as ActionList } from "./ActionList.vue";
 export { default as GithubSession } from "./Github.vue";
 export { default as RenameSession } from "./Rename.vue";
+export { default as DeployedPreview } from "./DeployedPreview.vue";

--- a/src/components/session/index.js
+++ b/src/components/session/index.js
@@ -4,3 +4,5 @@ export { default as ActionList } from "./ActionList.vue";
 export { default as GithubSession } from "./Github.vue";
 export { default as RenameSession } from "./Rename.vue";
 export { default as DeployedPreview } from "./DeployedPreview.vue";
+export { default as ActionTabSession } from "./ActionTabSession.vue";
+export { default as ActionSessions } from "./ActionSessions.vue";

--- a/src/enums.js
+++ b/src/enums.js
@@ -28,3 +28,7 @@ export const SCHEMA_MAP =
   globalThis.schemaMap || GIT_CLERK_CONFIG.schemaMap || [];
 export const AUTOMATION =
   globalThis.automation || GIT_CLERK_CONFIG.automation || [];
+export const DEPLOYED_PREVIEW_LINK =
+  globalThis.deployedPreviewLink ||
+  GIT_CLERK_CONFIG.deployedPreviewLink ||
+  (() => null);

--- a/src/helpers/query-session.js
+++ b/src/helpers/query-session.js
@@ -1,5 +1,4 @@
 import dayjs from "dayjs";
-import { DEPLOYED_PREVIEW_LINK } from "@/enums";
 import { getPrStatus } from "@/helpers";
 
 export default function querySession(session) {
@@ -8,7 +7,6 @@ export default function querySession(session) {
     date: dayjs(session.updated_at).format("DD/MM/YYYY"),
     time: dayjs(session.updated_at).format("hh:mm A"),
     status: getPrStatus(session),
-    deployedPreviewLink: DEPLOYED_PREVIEW_LINK(session),
     ...session,
   };
 }

--- a/src/helpers/query-session.js
+++ b/src/helpers/query-session.js
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
+import { DEPLOYED_PREVIEW_LINK } from "@/enums";
 import { getPrStatus } from "@/helpers";
 
 export default function querySession(session) {
@@ -7,6 +8,7 @@ export default function querySession(session) {
     date: dayjs(session.updated_at).format("DD/MM/YYYY"),
     time: dayjs(session.updated_at).format("hh:mm A"),
     status: getPrStatus(session),
+    deployedPreviewLink: DEPLOYED_PREVIEW_LINK(session),
     ...session,
   };
 }

--- a/src/methods/session-view/check-status-method.js
+++ b/src/methods/session-view/check-status-method.js
@@ -2,7 +2,7 @@ import { getCheckStatus, getSessionReviewStatus } from "@/api/index.js";
 import { CHECK_STATUS } from "@/enums.js";
 
 export default async function checkStatusMethod(session) {
-  const check = await getCheckStatus(session.value.number);
+  const check = await getCheckStatus(session.value.head.sha);
   const requestedChanges = await getSessionReviewStatus(session.value.number);
 
   session.value = {

--- a/src/methods/session-view/query-session-details.js
+++ b/src/methods/session-view/query-session-details.js
@@ -1,5 +1,6 @@
 import { RequestError } from "octokit";
 import { querySession } from "@/helpers";
+import { DEPLOYED_PREVIEW_LINK } from "@/enums";
 
 export default function querySessionDetailsMethod(sessionDetails, props) {
   if (sessionDetails instanceof RequestError) {
@@ -9,7 +10,10 @@ export default function querySessionDetailsMethod(sessionDetails, props) {
     };
     props.navPaginationItems.value = [props.navPaginationItems.value[0]];
   } else {
-    props.session.value = querySession(sessionDetails);
+    props.session.value = {
+      ...querySession(sessionDetails),
+      deployedPreviewLink: DEPLOYED_PREVIEW_LINK(sessionDetails),
+    };
     props.navPaginationItems.value = [
       props.navPaginationItems.value[0],
       {

--- a/src/methods/sessions-view/check-status-method.js
+++ b/src/methods/sessions-view/check-status-method.js
@@ -1,4 +1,8 @@
-import { getCheckStatus, getSessionReviewStatus } from "@/api/index.js";
+import {
+  getCheckStatus,
+  getSessionReviewStatus,
+  getSessionDetails,
+} from "@/api/index.js";
 import { CHECK_STATUS } from "@/enums.js";
 
 export default async function checkStatusMethod(
@@ -8,7 +12,8 @@ export default async function checkStatusMethod(
 ) {
   for (const [index, session] of sessions.value.entries()) {
     if (currPage === updatedPage.value) {
-      const check = await getCheckStatus(session.number);
+      const sessionDetails = await getSessionDetails(session.number);
+      const check = await getCheckStatus(sessionDetails.head.sha);
       const requestedChanges = await getSessionReviewStatus(session.number);
 
       if (currPage === updatedPage.value && sessions.value) {
@@ -16,6 +21,7 @@ export default async function checkStatusMethod(
           ...session,
           requested_changes: requestedChanges,
           check: CHECK_STATUS[check],
+          changed_files: sessionDetails.changed_files,
         };
       }
     }

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -10,13 +10,7 @@ import {
 import OctIcon from "@/components/global/OctIcon.vue";
 import ListPlaceholder from "@/components/global/ListPlaceholder.vue";
 import ListPagination from "@/components/global/ListPagination.vue";
-import {
-  DeleteFile,
-  ActionTabFileList,
-  CreateFile,
-  FileUploader,
-  DuplicateFile,
-} from "@/components/file";
+import { ActionTabSession } from "@/components/session";
 import { encodeString } from "@/helpers/index.js";
 import { BASE_PATH, AUTOMATION } from "@/enums";
 import "@eox/jsonform";
@@ -134,7 +128,7 @@ const handleAutomationClose = () => {
     :open="addNewFileDialog"
     :session
   />
-  <ActionTabFileList :session :updateDetails />
+  <ActionTabSession :session :updateDetails />
 
   <v-list class="py-0">
     <!-- file's list -->

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -11,6 +11,12 @@ import OctIcon from "@/components/global/OctIcon.vue";
 import ListPlaceholder from "@/components/global/ListPlaceholder.vue";
 import ListPagination from "@/components/global/ListPagination.vue";
 import { ActionTabSession } from "@/components/session";
+import {
+  DeleteFile,
+  CreateFile,
+  FileUploader,
+  DuplicateFile,
+} from "@/components/file";
 import { encodeString } from "@/helpers/index.js";
 import { BASE_PATH, AUTOMATION } from "@/enums";
 import "@eox/jsonform";


### PR DESCRIPTION
![CleanShot 2025-04-03 at 16 40 41@2x](https://github.com/user-attachments/assets/c81fc037-c141-494b-a073-338e94ddcde6)

## Implemented changes 
- Added `Deployed Preview` button using `config.js`
- Anyone can enable it by assigning `deployedPreviewLink()` in `config.js` to return a `deployed-preview` link
```js
globalThis.gitClerkConfig = {
  [...]
  deployedPreviewLink: (sessionDetail) => {
    const { number } = sessionDetail;
    return `https://deploy-preview-url.com/${number}/preview.html`;
  }
  [...]
};
```
- Also updated Action Tab style to adjust  action in `session` dropdown menu