### PR TITLE
feat: override jsonform options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ globalThis.gitClerkConfig = {
             type: "string"
           }
         }
+      },
+      jsonform: {
+        options: {} // jsonform options
       }
     },
     {

--- a/public/config.js
+++ b/public/config.js
@@ -69,6 +69,11 @@ const schemaMap = [
     content: {
       foo: "Initial content for file creation",
     },
+    jsonform: {
+      options: {
+        show_opt_in: false,
+      },
+    },
     preview: "/example-preview.html",
   },
 ];

--- a/public/config.js
+++ b/public/config.js
@@ -71,7 +71,8 @@ const schemaMap = [
     },
     jsonform: {
       options: {
-        show_opt_in: false,
+        disable_edit_json: false,
+        disable_properties: false,
       },
     },
     preview: "/example-preview.html",

--- a/src/views/FileEditView.vue
+++ b/src/views/FileEditView.vue
@@ -262,6 +262,7 @@ onUnmounted(() => {
           :schema="schemaMetaDetails.schema"
           :value="updatedFileContent"
           :customEditorInterfaces="customInterfaces"
+          :options="schemaMetaDetails.jsonform?.options || {}"
           @change="onFileChange"
           class="d-block fill-height"
         ></eox-jsonform>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/4c35d014-3463-44ba-b08b-7dfca12c52ab" width="48%" />
<img src="https://github.com/user-attachments/assets/9f6ea525-c62f-477b-8841-2e12cf44fa8b" width="48%" />

## Implementation 
- Added `jsonform` option part of `schemaMap`
```
globalThis.gitClerkConfig.schemaMap = [
  {
    path: "/foo/bar/<id>.json",
    schema: {},
    content: {},
    preview: "/example-preview.html",
    jsonform: {
      options: {...}
    }
  },
]
```