### PR TITLE
Fix: cursor pagination restricting next page number if `hasNextPage` not available"

### DIFF
--- a/src/components/global/CursorPagination.vue
+++ b/src/components/global/CursorPagination.vue
@@ -18,7 +18,11 @@ const props = defineProps({
 });
 
 const totalPages = computed(() => {
-  if (!props.pageInfo) return 1;
+  if (
+    !props.pageInfo ||
+    (props.currentPage === 1 && !props.pageInfo.hasNextPage)
+  )
+    return 1;
   return props.cursorHistory.length;
 });
 


### PR DESCRIPTION
<img width="1806" height="825" alt="CleanShot 2025-07-23 at 18 17 24" src="https://github.com/user-attachments/assets/9ef57aae-18cb-4919-8a38-39a287d401e4" />


## Implementation 
- Restricting next page number if `hasNextPage` not available 