### PR TITLE
Fix: trailing slash issue in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="./favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>git-clerk</title>
     <link
       href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css"
       rel="stylesheet"
     />
-    <script type="module" src="/config.js"></script>
+    <script type="module" src="./config.js"></script>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Implementaion 
**Issue:** App failed to load when deployed at `/hello/world/git-clerk` (without trailing slash) because absolute paths resolved to wrong locations.

**Fix:** Changed absolute paths to relative paths in `index.html`:
- `/config.js` → `./config.js`
- `/src/main.js` → `./src/main.js` 
- `/favicon.ico` → `./favicon.ico`

**Result:** App now works at both `/hello/world/git-clerk` and `/hello/world/git-clerk/`