### PR TITLE
feat: Add Dev Container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:22
+
+# Install Cypress dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    libgtk2.0-0 \
+    libgtk-3-0 \
+    libgbm-dev \
+    libnotify-dev \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    libxtst6 \
+    xauth \
+    xvfb \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Git Clerk Dev Environment",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "vitest.explorer"
+      ]
+    }
+  },
+  "forwardPorts": [5173],
+  "postCreateCommand": "npm install && npm install -g @google/gemini-cli",
+  "remoteEnv": {
+    "GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}"
+  },
+  "remoteUser": "node"
+}


### PR DESCRIPTION
## Summary

Adds a VS Code Dev Container setup for the Git Clerk project.

## Changes

- Adds a `.devcontainer/Dockerfile` based on Node.js 22.
- Installs required Cypress/system dependencies for browser-based testing.
- Adds `.devcontainer/devcontainer.json` with recommended VS Code extensions for Vue, ESLint, Prettier, and Vitest.
- Forwards the Vite dev server port `5173`.
- Runs `npm install` after container creation and installs `@google/gemini-cli` globally.
- Passes through `GEMINI_API_KEY` from the local environment.

## Testing

- Not run; configuration-only change.

---

done via Gemini CLI within VSCode

note: needs Dev Containers extension in VSCode...