### PR TITLE
fix: automation config is a reactive variable

### DIFF
--- a/cypress/e2e/files-list.cy.js
+++ b/cypress/e2e/files-list.cy.js
@@ -95,7 +95,7 @@ describe("Files list related tests", () => {
     cy.visit(
       "?session=update%203d%20earth&automation=add-file&content=ewogICJpZCI6ICI2MTFjNWQxNC03MDg3LTQ4MjAtYWNmNS02NDlhYWJjMjI0MjMiLAogICJmb28iOiAiRm9vIiwKICAiYmFyIjogZmFsc2UsCiAgImN1c3RvbSI6ICIiCn0K",
     );
-    cy.wait("@createPulls").then(() => {
+    cy.wait("@createPulls", { timeout: 15000 }).then(() => {
       cy.location("pathname", { timeout: 10000 }).should("eq", "/123");
     });
     cy.get("eox-jsonform#automation-form")

--- a/src/enums.js
+++ b/src/enums.js
@@ -1,3 +1,6 @@
+/* global globalThis */
+import { ref } from "vue";
+
 export const CHECK_STATUS = {
   success: {
     tooltip: "Validation Successful",
@@ -26,8 +29,25 @@ export const BASE_PATH =
   globalThis.basePath || GIT_CLERK_CONFIG.basePath || "/";
 export const SCHEMA_MAP =
   globalThis.schemaMap || GIT_CLERK_CONFIG.schemaMap || [];
-export const AUTOMATION =
-  globalThis.automation || GIT_CLERK_CONFIG.automation || [];
+
+export const AUTOMATION = ref(
+  globalThis.automation || GIT_CLERK_CONFIG.automation || [],
+);
+
+const _initialAutomation =
+  globalThis.automation || GIT_CLERK_CONFIG.automation;
+Object.defineProperty(globalThis, "automation", {
+  get() {
+    return AUTOMATION.value;
+  },
+  set(newVal) {
+    AUTOMATION.value = newVal;
+  },
+});
+if (_initialAutomation) {
+  AUTOMATION.value = _initialAutomation;
+}
+
 export const DEPLOYED_PREVIEW_LINK =
   globalThis.deployedPreviewLink ||
   GIT_CLERK_CONFIG.deployedPreviewLink ||

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -64,8 +64,8 @@ const updateDetails = async (cache = false) => {
 };
 
 watch(
-  AUTOMATION,
-  (newAutomation) => {
+  [AUTOMATION, session],
+  ([newAutomation, newSession]) => {
     const availableAutomation = [
       ...newAutomation.filter((automation) => !automation.hidden),
     ];
@@ -106,7 +106,7 @@ watch(
       };
     }
 
-    if (route.query.automation && !selectedAutomation.value) {
+    if (route.query.automation && !selectedAutomation.value && newSession) {
       const automation = find(newAutomation, { id: route.query.automation });
       if (automation) handleAutomationClick(automation);
     }

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, onMounted, ref } from "vue";
+import { inject, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { getFilesListFromSession, getSessionDetails } from "@/api/index.js";
 import {
@@ -63,52 +63,58 @@ const updateDetails = async (cache = false) => {
   }
 };
 
-onMounted(async () => {
-  const availableAutomation = [
-    ...AUTOMATION.filter((automation) => !automation.hidden),
-  ];
-
-  if (DISABLE_MANUAL_FILE_CREATION) {
-    suggestionList.value = availableAutomation;
-  } else {
-    suggestionList.value = [
-      ...availableAutomation,
-      {
-        title: "Add/Edit File Manually",
-        description:
-          "Create or edit a file by entering the file path and details manually.",
-        icon: "mdi-pencil-plus-outline",
-        func: () => (fileBrowserDrawer.value = true),
-        manual: true,
-      },
-      {
-        title: "Upload Files",
-        description: "Upload files from your computer.",
-        icon: "mdi-upload",
-        func: () => (fileBrowserDrawer.value = true),
-        manual: true,
-      },
+watch(
+  AUTOMATION,
+  (newAutomation) => {
+    const availableAutomation = [
+      ...newAutomation.filter((automation) => !automation.hidden),
     ];
-  }
 
-  if (availableAutomation.length) {
-    navButtonConfig.value = {
-      text: t("buttonText.automation"),
-      icon: "mdi-auto-fix",
-      list: availableAutomation.map((suggestion) => ({
-        ...suggestion,
-        click: () => handleAutomationClick(suggestion),
+    if (DISABLE_MANUAL_FILE_CREATION) {
+      suggestionList.value = availableAutomation;
+    } else {
+      suggestionList.value = [
+        ...availableAutomation,
+        {
+          title: "Add/Edit File Manually",
+          description:
+            "Create or edit a file by entering the file path and details manually.",
+          icon: "mdi-pencil-plus-outline",
+          func: () => (fileBrowserDrawer.value = true),
+          manual: true,
+        },
+        {
+          title: "Upload Files",
+          description: "Upload files from your computer.",
+          icon: "mdi-upload",
+          func: () => (fileBrowserDrawer.value = true),
+          manual: true,
+        },
+      ];
+    }
+
+    if (availableAutomation.length) {
+      navButtonConfig.value = {
+        text: t("buttonText.automation"),
         icon: "mdi-auto-fix",
-      })),
-      disabled: true,
-    };
-  }
+        list: availableAutomation.map((suggestion) => ({
+          ...suggestion,
+          click: () => handleAutomationClick(suggestion),
+          icon: "mdi-auto-fix",
+        })),
+        disabled: navButtonConfig.value?.disabled ?? true,
+      };
+    }
 
-  if (route.query.automation) {
-    const automation = find(AUTOMATION, { id: route.query.automation });
-    if (automation) handleAutomationClick(automation);
-  }
+    if (route.query.automation && !selectedAutomation.value) {
+      const automation = find(newAutomation, { id: route.query.automation });
+      if (automation) handleAutomationClick(automation);
+    }
+  },
+  { immediate: true, deep: true },
+);
 
+onMounted(async () => {
   await updateDetails();
 });
 

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -271,4 +271,3 @@ const resetWholeState = async () => {
     :cursorHistory="cursorHistory"
   />
 </template>
-ate>

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import OctIcon from "@/components/global/OctIcon.vue";
-import { h, inject, onMounted, ref } from "vue";
+import { h, inject, onMounted, ref, watch } from "vue";
 import {
   getSessionsList,
   createSessionByName,
@@ -11,6 +11,7 @@ import {
   querySessionsListMethod,
   checkStatusMethod,
 } from "@/methods/sessions-view";
+import { AUTOMATION } from "@/enums";
 import { useRoute, useRouter } from "vue-router";
 import Tooltip from "@/components/global/Tooltip.vue";
 import {
@@ -108,19 +109,31 @@ onMounted(async () => {
   };
   navPaginationItems.value = [navPaginationItems.value[0]];
 
-  if (route.query.session && route.query.automation) {
-    newSessionName.value = route.query.session;
-    await createSession(
-      {
-        newSessionName,
-        snackbar,
-        loader,
-      },
-      router,
-      route,
-      clearInputCreateNewSession,
-    );
-  }
+  watch(
+    AUTOMATION,
+    async (newAutomation) => {
+      if (
+        route.query.session &&
+        route.query.automation &&
+        find(newAutomation, { id: route.query.automation }) &&
+        !newSessionName.value
+      ) {
+        newSessionName.value = route.query.session;
+        await createSession(
+          {
+            newSessionName,
+            snackbar,
+            loader,
+          },
+          router,
+          route,
+          clearInputCreateNewSession,
+        );
+      }
+    },
+    { immediate: true },
+  );
+
   await updateSessionsList(true);
 });
 
@@ -258,3 +271,4 @@ const resetWholeState = async () => {
     :cursorHistory="cursorHistory"
   />
 </template>
+ate>

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import OctIcon from "@/components/global/OctIcon.vue";
-import { h, inject, onMounted, ref, watch } from "vue";
+import { h, inject, onMounted, ref } from "vue";
 import {
   getSessionsList,
   createSessionByName,
@@ -11,7 +11,6 @@ import {
   querySessionsListMethod,
   checkStatusMethod,
 } from "@/methods/sessions-view";
-import { AUTOMATION } from "@/enums";
 import { useRoute, useRouter } from "vue-router";
 import Tooltip from "@/components/global/Tooltip.vue";
 import {
@@ -109,31 +108,19 @@ onMounted(async () => {
   };
   navPaginationItems.value = [navPaginationItems.value[0]];
 
-  watch(
-    AUTOMATION,
-    async (newAutomation) => {
-      if (
-        route.query.session &&
-        route.query.automation &&
-        find(newAutomation, { id: route.query.automation }) &&
-        !newSessionName.value
-      ) {
-        newSessionName.value = route.query.session;
-        await createSession(
-          {
-            newSessionName,
-            snackbar,
-            loader,
-          },
-          router,
-          route,
-          clearInputCreateNewSession,
-        );
-      }
-    },
-    { immediate: true },
-  );
-
+  if (route.query.session && route.query.automation) {
+    newSessionName.value = route.query.session;
+    await createSession(
+      {
+        newSessionName,
+        snackbar,
+        loader,
+      },
+      router,
+      route,
+      clearInputCreateNewSession,
+    );
+  }
   await updateSessionsList(true);
 });
 


### PR DESCRIPTION
In Narrative Editor some configs create the automation only after fetching a remote endpoint to get the enums for schema. Delayed setting of the `globalThis.automation` caused the automation to not be available early enough and thefore not loaded at all.

This PR changes the automation to ref (I intentionally modified the code just for this one config to keep the change small)

close https://github.com/EOX-A/git-clerk/issues/232