### PR TITLE
feat: edit existing session through external automation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,12 @@ globalThis.gitClerkConfig = {
 
 Automations can also be triggered via url query parameters. For this, the automation requires an additional `id` parameter which is referenced by the `automation` query parameter.
 
-The automation can either be triggered within a session, or, additionally, a `session` parameter can be passed in order to create a new session in this name.
+The automation can be triggered within a session, or you can supply `session` or `sessionNumber` parameters:
 
-All other query parameters (except `automation` and `session`) are passed as key-value pairs into the automation input (and thus can further be used in automation steps).
+- `session`: The title of the session. If an open session/pull request with this exact title already exists for the user, git-clerk will reuse and open that existing session. If no matching open session is found, it will automatically create a new one. (Note: If a name collision occurs on GitHub, such as during manual creation or with closed/orphaned branches, git-clerk will still automatically append an incremented suffix like `(1)`, `(2)`, etc., to prevent branch collisions).
+- `sessionNumber`: The specific number of an existing session (pull request) to target directly.
+
+All other query parameters (except `automation`, `session`, and `sessionNumber`) are passed as key-value pairs into the automation input (and thus can further be used in automation steps).
 
 Example:
 `https://my-git-clerk-instance.com?session=My New Session&automation=automation-id&field1=value-field1&field2=value-field2`

--- a/cypress/e2e/files-list.cy.js
+++ b/cypress/e2e/files-list.cy.js
@@ -90,32 +90,12 @@ describe("Files list related tests", () => {
   });
 
   it("Automation through url", () => {
-    let location;
-    cy.wait(1000);
     cy.visit(
-      "?session=update%203d%20earth&automation=add-file&content=ewogICJpZCI6ICI2MTFjNWQxNC03MDg3LTQ4MjAtYWNmNS02NDlhYWJjMjI0MjMiLAogICJmb28iOiAiRm9vIiwKICAiYmFyIjogZmFsc2UsCiAgImN1c3RvbSI6ICIiCn0K",
+      "?sessionNumber=123&automation=add-file&fileName=bar.json&content=ewogICJpZCI6ICI2MTFjNWQxNC03MDg3LTQ4MjAtYWNmNS02NDlhYWJjMjI0MjMiLAogICJmb28iOiAiRm9vIiwKICAiYmFyIjogZmFsc2UsCiAgImN1c3RvbSI6ICIiCn0K",
     );
-    cy.wait("@createPulls", { timeout: 15000 }).then(() => {
-      cy.location("pathname", { timeout: 10000 }).should("eq", "/123");
-    });
-    cy.get("eox-jsonform#automation-form")
-      .shadow()
-      .within(() => {
-        cy.get(
-          ".je-indented-panel .form-control input[name='root[id]']",
-        ).should("exist");
-        cy.get(".je-indented-panel .form-control input[name='root[id]']").then(
-          ($input) => {
-            location = btoa(`foo/bar/${$input.val()}.json`);
-            cy.wrap(location).as("encodedPath");
-          },
-        );
-      });
-    cy.wait("@getContent", { timeout: 10000 });
-    cy.get("@encodedPath").then((location) => {
-      cy.location("pathname", { timeout: 10000 }).should((path) => {
-        expect(path).to.match(/^\/123\/[A-Za-z0-9+/=]+$/);
-      });
+    cy.location("pathname", { timeout: 10000 }).should("eq", "/123");
+    cy.location("pathname", { timeout: 10000 }).should((path) => {
+      expect(path).to.match(/^\/123\/[A-Za-z0-9+/=]+$/);
     });
 
     // Check if the file is loaded

--- a/public/config.js
+++ b/public/config.js
@@ -131,25 +131,21 @@ const automation = [
     inputSchema: {
       type: "object",
       properties: {
-        id: {
+        fileName: {
           type: "string",
           minLength: 1,
-          default: self.crypto.randomUUID(),
-          options: {
-            hidden: true,
-          },
         },
         content: {
           type: "string",
           minLength: 1,
         },
       },
-      required: ["id", "content"],
+      required: ["fileName"],
     },
     steps: [
       {
         type: "add",
-        path: (input) => `/foo/${input.id}.json`,
+        path: (input) => `/foo/${input.fileName}`,
         content: async (input) => {
           let content = input.content;
           let error = null;
@@ -184,20 +180,22 @@ const automation = [
             }
           }
 
-          try {
-            if (isUrl(content)) {
-              const response = await fetch(content);
-              if (!response.ok) {
-                throw new Error("Failed to fetch content from URL");
+          if (content) {
+            try {
+              if (isUrl(content)) {
+                const response = await fetch(content);
+                if (!response.ok) {
+                  throw new Error("Failed to fetch content from URL");
+                }
+                content = await response.json();
+              } else if (isBase64(content)) {
+                content = decoderBase64ToUtf8(content);
+              } else {
+                content = decodeURIComponent(content);
               }
-              content = await response.json();
-            } else if (isBase64(content)) {
-              content = decoderBase64ToUtf8(content);
-            } else {
-              content = decodeURIComponent(content);
+            } catch (e) {
+              error = e;
             }
-          } catch (e) {
-            error = e;
           }
 
           return error || content;
@@ -205,7 +203,7 @@ const automation = [
       },
       {
         type: "navigate",
-        path: (input) => `/foo/${input.id}.json`,
+        path: (input) => `/foo/${input.fileName}`,
       },
     ],
   },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -92,12 +92,36 @@ export async function getSessionsList(
   cache,
 ) {
   const { githubConfig, githubUserData, octokit } = useOctokitStore();
+  const sessionNameValue = "";
+
   return sessionsList(
     octokit,
     githubConfig,
     pageInfo,
     cursorPosition,
     sessionSelectedState,
+    sessionNameValue,
+    cache,
+    githubUserData.login,
+  );
+}
+
+export async function searchSessionName(
+  sessionName,
+  pageInfo,
+  cursorPosition,
+  sessionSelectedState = "open",
+  cache,
+) {
+  const { githubConfig, githubUserData, octokit } = useOctokitStore();
+  const sessionNameValue = `${sessionName} `;
+  return sessionsList(
+    octokit,
+    githubConfig,
+    pageInfo,
+    cursorPosition,
+    sessionSelectedState,
+    sessionNameValue,
     cache,
     githubUserData.login,
   );

--- a/src/api/session.js
+++ b/src/api/session.js
@@ -46,7 +46,7 @@ export async function sessionsList(
     `;
 
     const response = await octokit.graphql(query, {
-      queryString: `${sessionName} repo:${githubConfig.username}/${githubConfig.repo} is:pr author:${creator} state:${sessionSelectedState}`,
+      queryString: `${sessionName}repo:${githubConfig.username}/${githubConfig.repo} is:pr author:${creator} state:${sessionSelectedState}`,
       perPage: 10,
       after:
         cursorPosition === "endCursor"

--- a/src/api/session.js
+++ b/src/api/session.js
@@ -7,6 +7,7 @@ export async function sessionsList(
   pageInfo,
   cursorPosition,
   sessionSelectedState,
+  sessionName,
   cache,
   creator,
 ) {
@@ -45,7 +46,7 @@ export async function sessionsList(
     `;
 
     const response = await octokit.graphql(query, {
-      queryString: `repo:${githubConfig.username}/${githubConfig.repo} is:pr author:${creator} state:${sessionSelectedState}`,
+      queryString: `${sessionName} repo:${githubConfig.username}/${githubConfig.repo} is:pr author:${creator} state:${sessionSelectedState}`,
       perPage: 10,
       after:
         cursorPosition === "endCursor"

--- a/src/enums.js
+++ b/src/enums.js
@@ -34,8 +34,7 @@ export const AUTOMATION = ref(
   globalThis.automation || GIT_CLERK_CONFIG.automation || [],
 );
 
-const _initialAutomation =
-  globalThis.automation || GIT_CLERK_CONFIG.automation;
+const _initialAutomation = globalThis.automation || GIT_CLERK_CONFIG.automation;
 Object.defineProperty(globalThis, "automation", {
   get() {
     return AUTOMATION.value;

--- a/src/helpers/create-session.js
+++ b/src/helpers/create-session.js
@@ -2,6 +2,35 @@ import { createSessionByName } from "@/api/index.js";
 import { useLoader } from "@/helpers/index.js";
 import { h } from "vue";
 
+export function postSessionCreation(
+  sessionNumber,
+  router,
+  route,
+  clearInput,
+  filePath,
+  noRedirectCallback,
+) {
+  const params = Object.fromEntries(
+    Object.entries(route.query).filter(
+      ([key]) => key !== "session" && key !== "file-browser",
+    ),
+  );
+  const queryString = new URLSearchParams(params).toString();
+  const filePathToOpen = filePath ? filePath() : null;
+  const url = Boolean(queryString)
+    ? `/${sessionNumber}?${queryString}`
+    : `/${sessionNumber}${filePathToOpen ? `/${filePathToOpen}` : ""}`;
+
+  if (!noRedirectCallback) {
+    setTimeout(() => {
+      router.push(url);
+      clearInput(true);
+    }, 750);
+  } else {
+    noRedirectCallback(sessionNumber);
+  }
+}
+
 export default async function createSession(
   props,
   router,
@@ -31,25 +60,13 @@ export default async function createSession(
   props.loader.value.hide();
 
   if (props.snackbar.value.number) {
-    const params = Object.fromEntries(
-      Object.entries(route.query).filter(
-        ([key]) => key !== "session" && key !== "file-browser",
-      ),
+    postSessionCreation(
+      props.snackbar.value.number,
+      router,
+      route,
+      clearInput,
+      filePath,
+      noRedirectCallback,
     );
-    const queryString = new URLSearchParams(params).toString();
-    const filePathToOpen = filePath ? filePath() : null;
-    const sessionNumber = props.snackbar.value.number;
-    const url = Boolean(queryString)
-      ? `/${sessionNumber}?${queryString}`
-      : `/${sessionNumber}${filePathToOpen ? `/${filePathToOpen}` : ""}`;
-
-    if (!noRedirectCallback) {
-      setTimeout(() => {
-        router.push(url);
-        clearInput(true);
-      }, 750);
-    } else {
-      noRedirectCallback(sessionNumber);
-    }
   }
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -12,5 +12,8 @@ export { getSchemaDetails, getFileSchema } from "./schema";
 export { stringifyIfNeeded, parseIfNeeded } from "./transform";
 export { runAutomation } from "./automation";
 export { default as preventListItemClick } from "./prevent-list-item-click";
-export { default as createSession } from "./create-session";
+export {
+  default as createSession,
+  postSessionCreation,
+} from "./create-session";
 export { default as fetchJsonFormContent } from "./fetch-json-form-content";

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -4,6 +4,7 @@ import { h, inject, onMounted, ref } from "vue";
 import {
   getSessionsList,
   createSessionByName,
+  searchSessionName,
   getNumberOfOpenClosedSessions,
   syncRepo,
 } from "@/api/index.js";
@@ -17,6 +18,7 @@ import {
   useLoader,
   preventListItemClick,
   createSession,
+  postSessionCreation,
 } from "@/helpers/index.js";
 import {
   ActionList,
@@ -27,6 +29,7 @@ import {
 import ListPlaceholder from "@/components/global/ListPlaceholder.vue";
 import CursorPagination from "@/components/global/CursorPagination.vue";
 import { FileBrowserDrawer } from "@/components/file-browser";
+import find from "lodash.find";
 
 const route = useRoute();
 const router = useRouter();
@@ -108,18 +111,39 @@ onMounted(async () => {
   };
   navPaginationItems.value = [navPaginationItems.value[0]];
 
-  if (route.query.session && route.query.automation) {
+  if (
+    (route.query.session || route.query.sessionNumber) &&
+    route.query.automation
+  ) {
+    const sessionNumber = route.query.sessionNumber;
     newSessionName.value = route.query.session;
-    await createSession(
-      {
-        newSessionName,
-        snackbar,
-        loader,
-      },
-      router,
-      route,
-      clearInputCreateNewSession,
-    );
+    const sessionsList = sessionNumber
+      ? null
+      : await searchSessionName(newSessionName.value, null, null, "open");
+    const sessionFound = sessionNumber
+      ? { number: sessionNumber }
+      : find(sessionsList?.data ? sessionsList.data : [], {
+          title: newSessionName.value,
+        });
+    if (sessionFound) {
+      postSessionCreation(
+        sessionFound.number,
+        router,
+        route,
+        clearInputCreateNewSession,
+      );
+    } else {
+      await createSession(
+        {
+          newSessionName,
+          snackbar,
+          loader,
+        },
+        router,
+        route,
+        clearInputCreateNewSession,
+      );
+    }
   }
   await updateSessionsList(true);
 });

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -117,14 +117,21 @@ onMounted(async () => {
   ) {
     const sessionNumber = route.query.sessionNumber;
     newSessionName.value = route.query.session;
-    const sessionsList = sessionNumber
-      ? null
-      : await searchSessionName(newSessionName.value, null, null, "open");
-    const sessionFound = sessionNumber
-      ? { number: sessionNumber }
-      : find(sessionsList?.data ? sessionsList.data : [], {
-          title: newSessionName.value,
-        });
+
+    let sessionFound = null;
+
+    if (sessionNumber) {
+      sessionFound = { number: sessionNumber };
+    } else if (newSessionName.value) {
+      const sessionsList = await searchSessionName(
+        newSessionName.value,
+        null,
+        null,
+        "open",
+      );
+      const sessionsData = sessionsList?.data || [];
+      sessionFound = find(sessionsData, { title: newSessionName.value });
+    }
     if (sessionFound) {
       postSessionCreation(
         sessionFound.number,
@@ -133,16 +140,12 @@ onMounted(async () => {
         clearInputCreateNewSession,
       );
     } else {
-      await createSession(
-        {
-          newSessionName,
-          snackbar,
-          loader,
-        },
-        router,
-        route,
-        clearInputCreateNewSession,
-      );
+      const props = {
+        newSessionName,
+        snackbar,
+        loader,
+      };
+      await createSession(props, router, route, clearInputCreateNewSession);
     }
   }
   await updateSessionsList(true);


### PR DESCRIPTION
## Implementation 
- Added editing an existing session using an external automation URL.
- URL must contain `session` or `sessionNumber` to make this work.
- The automation flow must be correct to make the edit work in correct sync 

```url
/session={session-name}&automation={automation-name}&autiomation-related-queries=${...}
```