### PR TITLE
chore(refactor): remove unused file-browser parameter and clean welcome screen

### DIFF
--- a/src/components/session/WelcomeSection.vue
+++ b/src/components/session/WelcomeSection.vue
@@ -38,14 +38,12 @@ const welcomeCards = ref([
 ]);
 
 const selectedCard = (type) => {
-  const url = new URL(window.location.href);
   selectedType.value = type;
   if (type === "propose") {
     fileBrowserDrawer.value = type;
   } else {
     props.createNewSessionClick();
   }
-  window.history.replaceState({}, "", url);
 };
 </script>
 

--- a/src/helpers/create-session.js
+++ b/src/helpers/create-session.js
@@ -11,13 +11,11 @@ export function postSessionCreation(
   noRedirectCallback,
 ) {
   const params = Object.fromEntries(
-    Object.entries(route.query).filter(
-      ([key]) => key !== "session" && key !== "file-browser",
-    ),
+    Object.entries(route.query).filter(([key]) => key !== "session"),
   );
   const queryString = new URLSearchParams(params).toString();
   const filePathToOpen = filePath ? filePath() : null;
-  const url = Boolean(queryString)
+  const url = queryString
     ? `/${sessionNumber}?${queryString}`
     : `/${sessionNumber}${filePathToOpen ? `/${filePathToOpen}` : ""}`;
 


### PR DESCRIPTION
This PR cleans up unused code, dead variables, and redundant URL manipulations associated with the `file-browser` query parameter.

### Key Changes:

1. **Removed `file-browser` filter in `src/helpers/create-session.js`:**
   The `file-browser` query parameter was being filtered out during the redirection of a newly created session to prevent parameter pollution. Since `file-browser` is not actually used as a query parameter in the codebase, this filtering logic is redundant and has been removed.
2. **Fixed Redundant `Boolean` check in `src/helpers/create-session.js`:**
   Cleaned up a redundant `Boolean(queryString)` call (flagged as a `no-extra-boolean-cast` lint error) to check standard truthiness of `queryString`.

3. **Removed No-Op URL Parsing in `src/components/session/WelcomeSection.vue`:**
   In `selectedCard`, `new URL(window.location.href)` was parsed and immediately used in `window.history.replaceState({}, "", url)` without any modifications. This is a leftover from a planned feature that was never completed (which would have set the query parameter in the URL). This redundant logic has been removed, and the file has been successfully formatted and linted.

## Verification

- Checked that formatting conforms to the Prettier configuration.
- Successfully verified that ESLint reports `0` errors/warnings on the modified files.
- Ran the full test suite via `npm test` and verified that all specs pass successfully.