### PR TITLE
feat: external automation with js

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,15 @@ Automations can also be triggered via -
 
    Example:`https://my-git-clerk-instance.com?session=My New Session&automation=automation-id&field1=value-field1&field2=value-field2`
 
-2. `postMessage` from parent tab - when git-clerk is opened from another application, it sends an `'automation-ready'` message to its parent window or opener once it is loaded. The parent can then listen for this message and reply with a `postMessage` containing the automation data as a JSON string. The automation data should include `session` or `sessionNumber` (similar to url query params), `automation` (automation id), and any other key-value pairs required by the automation input.
+2. `postMessage` from parent tab - when git-clerk is opened from another application, it sends an `'automation-ready'` message to its parent window or opener once it is loaded. The parent can then listen for this message and reply with a `postMessage` containing the automation data as a JSON string. The automation data should include `session` or `sessionNumber` (similar to url query params), `automation` (automation id), and any other key-value pairs required by the automation input. This is only applicable if `allowedOrigins` is provided in `config.js`.
 
    Example:
+
+   ```js
+   // config.js
+   const allowedOrigins = ["http://example.website"];
+   globalThis.gitClerkConfig.allowedOrigins = allowedOrigins;
+   ```
 
    ```html
    <a href="/" target="_blank" rel="opener">Git Clerk</a>

--- a/README.md
+++ b/README.md
@@ -195,17 +195,40 @@ globalThis.gitClerkConfig = {
 };
 ```
 
-Automations can also be triggered via url query parameters. For this, the automation requires an additional `id` parameter which is referenced by the `automation` query parameter.
+Automations can also be triggered via -
 
-The automation can be triggered within a session, or you can supply `session` or `sessionNumber` parameters:
+1. URL Query Parameters - for this, the automation requires an additional `id` parameter which is referenced by the `automation` query parameter. The automation can be triggered within a session, or you can supply `session` or `sessionNumber` parameters:
+   - `session`: The title of the session. If an open session/pull request with this exact title already exists for the user, git-clerk will reuse and open that existing session. If no matching open session is found, it will automatically create a new one. (Note: If a name collision occurs on GitHub, such as during manual creation or with closed/orphaned branches, git-clerk will still automatically append an incremented suffix like `(1)`, `(2)`, etc., to prevent branch collisions).
+   - `sessionNumber`: The specific number of an existing session (pull request) to target directly.
 
-- `session`: The title of the session. If an open session/pull request with this exact title already exists for the user, git-clerk will reuse and open that existing session. If no matching open session is found, it will automatically create a new one. (Note: If a name collision occurs on GitHub, such as during manual creation or with closed/orphaned branches, git-clerk will still automatically append an incremented suffix like `(1)`, `(2)`, etc., to prevent branch collisions).
-- `sessionNumber`: The specific number of an existing session (pull request) to target directly.
+   All other query parameters (except `automation`, `session`, and `sessionNumber`) are passed as key-value pairs into the automation input (and thus can further be used in automation steps).
 
-All other query parameters (except `automation`, `session`, and `sessionNumber`) are passed as key-value pairs into the automation input (and thus can further be used in automation steps).
+   Example:`https://my-git-clerk-instance.com?session=My New Session&automation=automation-id&field1=value-field1&field2=value-field2`
 
-Example:
-`https://my-git-clerk-instance.com?session=My New Session&automation=automation-id&field1=value-field1&field2=value-field2`
+2. `postMessage` from parent tab - when git-clerk is opened from another application, it sends an `'automation-ready'` message to its parent window or opener once it is loaded. The parent can then listen for this message and reply with a `postMessage` containing the automation data as a JSON string. The automation data should include `session` or `sessionNumber` (similar to url query params), `automation` (automation id), and any other key-value pairs required by the automation input.
+
+   Example:
+
+   ```javascript
+   const automationData = {
+     session: "My New Session",
+     automation: "automation-id",
+     field1: "value-field1",
+     field2: "value-field2",
+   };
+   ```
+
+let readyAutomation = false; // This will prevent event from triggering multiple times.
+window.addEventListener('message', (event) => {
+if (event.data === 'automation-ready' && !readyAutomation) {
+event.source.postMessage(JSON.stringify(automationData), '\*');
+readyAutomation = true;
+}
+});
+
+````
+
+Example - [external automation through js](/public/example-external-automation.html)
 
 ### Custom Editor Interface
 
@@ -213,18 +236,18 @@ Git Clerk uses `eox-jsonform` to render applications based on different JSON edi
 
 ```js
 globalThis.gitClerkConfig = {
-  [...]
-  customEditorInterfaces: {
-    "some-format-key-name": {
-      type: "string", // Any data type for the custom editor
-      format: "any-custom-format", // Any custom format key
-      func: CustomEditorInterface, // Build any custom editor using `JSON Editor`'s `AbstractEditor` class
-      ... // Add any key values as per your business logic
-    },
-  },
-  [...]
+[...]
+customEditorInterfaces: {
+ "some-format-key-name": {
+   type: "string", // Any data type for the custom editor
+   format: "any-custom-format", // Any custom format key
+   func: CustomEditorInterface, // Build any custom editor using `JSON Editor`'s `AbstractEditor` class
+   ... // Add any key values as per your business logic
+ },
+},
+[...]
 };
-```
+````
 
 An example for this setup can be seen in [here](https://github.com/EOX-A/git-clerk/blob/bfa157a499ef488fe3b0ebf3215fb9368d552496/public/config.js#L680).
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Automations can also be triggered via -
 
    Example:
 
+   ```html
+   <a href="/" target="_blank" rel="opener">Git Clerk</a>
+   ```
+
    ```javascript
    const automationData = {
      session: "My New Session",

--- a/README.md
+++ b/README.md
@@ -216,17 +216,14 @@ Automations can also be triggered via -
      field1: "value-field1",
      field2: "value-field2",
    };
+   let readyAutomation = false; // This will prevent event from triggering multiple times.
+   window.addEventListener("message", (event) => {
+     if (event.data === "automation-ready" && !readyAutomation) {
+       event.source.postMessage(JSON.stringify(automationData), "\*");
+       readyAutomation = true;
+     }
+   });
    ```
-
-let readyAutomation = false; // This will prevent event from triggering multiple times.
-window.addEventListener('message', (event) => {
-if (event.data === 'automation-ready' && !readyAutomation) {
-event.source.postMessage(JSON.stringify(automationData), '\*');
-readyAutomation = true;
-}
-});
-
-````
 
 Example - [external automation through js](/public/example-external-automation.html)
 
@@ -247,7 +244,7 @@ customEditorInterfaces: {
 },
 [...]
 };
-````
+```
 
 An example for this setup can be seen in [here](https://github.com/EOX-A/git-clerk/blob/bfa157a499ef488fe3b0ebf3215fb9368d552496/public/config.js#L680).
 

--- a/cypress/e2e/files-list.cy.js
+++ b/cypress/e2e/files-list.cy.js
@@ -15,6 +15,14 @@ let isUploadFile = false;
 // Test file path constant
 const fileName = "products/foo2/collection.json";
 
+const automationData = {
+  sessionNumber: 123,
+  automation: "add-file",
+  fileName: "bar.json",
+  content:
+    "ewogICJpZCI6ICI2MTFjNWQxNC03MDg3LTQ4MjAtYWNmNS02NDlhYWJjMjI0MjMiLAogICJmb28iOiAiRm9vIiwKICAiYmFyIjogZmFsc2UsCiAgImN1c3RvbSI6ICIiCn0K",
+};
+
 describe("Files list related tests", () => {
   beforeEach(() => {
     // Intercept GET request for pull request details
@@ -89,10 +97,37 @@ describe("Files list related tests", () => {
     ).as("getContent");
   });
 
+  // Test automation through url
   it("Automation through url", () => {
-    cy.visit(
-      "?sessionNumber=123&automation=add-file&fileName=bar.json&content=ewogICJpZCI6ICI2MTFjNWQxNC03MDg3LTQ4MjAtYWNmNS02NDlhYWJjMjI0MjMiLAogICJmb28iOiAiRm9vIiwKICAiYmFyIjogZmFsc2UsCiAgImN1c3RvbSI6ICIiCn0K",
-    );
+    let qs = "?";
+    Object.keys(automationData).forEach((key) => {
+      qs += `${key}=${automationData[key]}&`;
+    });
+    cy.visit(qs);
+    cy.location("pathname", { timeout: 10000 }).should("eq", "/123");
+    cy.location("pathname", { timeout: 10000 }).should((path) => {
+      expect(path).to.match(/^\/123\/[A-Za-z0-9+/=]+$/);
+    });
+
+    // Check if the file is loaded
+    cy.get("eox-jsonform").should("exist");
+    cy.get("eox-jsonform")
+      .shadow()
+      .within(() => {
+        // Check if the file is loaded
+        cy.get(".je-indented-panel .ace_editor .ace_line").should(
+          "have.text",
+          atob(content.content).replaceAll("\n", ""),
+        );
+      });
+  });
+
+  // Test automation through post message
+  it("Automation through post message", () => {
+    cy.visit("/");
+    cy.window().then((win) => {
+      win.postMessage(JSON.stringify(automationData), "*");
+    });
     cy.location("pathname", { timeout: 10000 }).should("eq", "/123");
     cy.location("pathname", { timeout: 10000 }).should((path) => {
       expect(path).to.match(/^\/123\/[A-Za-z0-9+/=]+$/);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,9 +1703,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1720,9 +1717,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1737,9 +1731,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1754,9 +1745,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1771,9 +1759,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,9 +1773,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1805,9 +1787,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1822,9 +1801,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1839,9 +1815,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1856,9 +1829,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1873,9 +1843,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1890,9 +1857,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1907,9 +1871,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3377,9 +3338,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4139,16 +4100,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4404,9 +4365,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4737,10 +4699,20 @@
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6159,10 +6131,11 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -6433,9 +6406,9 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6611,9 +6584,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/public/config.js
+++ b/public/config.js
@@ -293,6 +293,8 @@ const i18n = {
   },
 };
 
+const allowedOrigins = [import.meta.url.replace("/config.js", "")];
+
 globalThis.gitClerkConfig = {
   ghConfig,
   basePath,
@@ -303,4 +305,5 @@ globalThis.gitClerkConfig = {
   deployedPreviewLink,
   disableManualFileCreation,
   i18n,
+  allowedOrigins,
 };

--- a/public/example-external-automation.html
+++ b/public/example-external-automation.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>External Automation</title>
+</head>
+<body>
+  <a class="open-link" href="/" target="_blank" rel="opener">Open External Automation</a>
+  <script>
+    let readyAutomation = false;
+    window.addEventListener('message', (event) => {
+      if (event.data === 'automation-ready') {
+        console.log("automation-ready", event)
+        if(!readyAutomation) {
+          event.source.postMessage(JSON.stringify({
+            "session": "Test Automation",
+            "automation": "add-file",
+            "content": "R2l0IGNsZXJrIGF1dG9tYXRpb24=",
+            "fileName": "automation.txt"
+          }), '*');
+          console.log("Message sent")
+          readyAutomation = true;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public/example-external-automation.html
+++ b/public/example-external-automation.html
@@ -6,17 +6,19 @@
 <body>
   <a class="open-link" href="/" target="_blank" rel="opener">Open External Automation</a>
   <script>
+    const mainExampleData = {
+      "session": "Test Automation",
+      "automation": "add-file",
+      "content": "R2l0IGNsZXJrIGF1dG9tYXRpb24=",
+      "fileName": "automation.txt"
+    }
+
     let readyAutomation = false;
     window.addEventListener('message', (event) => {
       if (event.data === 'automation-ready') {
         console.log("automation-ready", event)
         if(!readyAutomation) {
-          event.source.postMessage(JSON.stringify({
-            "session": "Test Automation",
-            "automation": "add-file",
-            "content": "R2l0IGNsZXJrIGF1dG9tYXRpb24=",
-            "fileName": "automation.txt"
-          }), '*');
+          event.source.postMessage(JSON.stringify(mainExampleData), '*');
           console.log("Message sent")
           readyAutomation = true;
         }

--- a/src/components/session/Automation.vue
+++ b/src/components/session/Automation.vue
@@ -3,15 +3,19 @@ import { CUSTOM_EDITOR_INTERFACES } from "@/enums";
 import { initEOXJSONFormMethod } from "@/methods/file-edit-view";
 import { handleAutomationMethod } from "@/methods/session-view";
 import { inject, ref, onMounted } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRouter } from "vue-router";
+import useAutomationStore from "@/stores/automation";
+import { storeToRefs } from "pinia";
+
 const snackbar = inject("set-snackbar");
-const route = useRoute();
 const router = useRouter();
 
+const automationStore = useAutomationStore();
+const { selectedAutomation, automation, externalAutomationData } =
+  storeToRefs(automationStore);
+const { handleAutomationClose, resetExternalAutomation } = automationStore;
+
 const props = defineProps({
-  selectedAutomation: Object,
-  automationDialog: Boolean,
-  handleAutomationClose: Function,
   updateDetails: Function,
   session: Object,
 });
@@ -26,12 +30,15 @@ const handleAutomationSubmit = async () => {
 };
 
 onMounted(() => {
-  if (route.query.automation && props.selectedAutomation.hidden) {
+  if (automation.value && selectedAutomation.value.hidden) {
     initValue.value = Object.fromEntries(
-      Object.entries(route.query).filter(([key]) => key !== "automation"),
+      Object.entries(externalAutomationData.value).filter(
+        ([key]) => key !== "automation",
+      ),
     );
     setTimeout(() => {
       handleAutomationSubmit();
+      resetExternalAutomation();
     }, 2000);
   }
   initEOXJSONFormMethod(jsonFormInstance);
@@ -40,15 +47,15 @@ onMounted(() => {
 
 <template>
   <v-card
-    v-if="props.selectedAutomation"
+    v-if="selectedAutomation"
     prepend-icon="mdi-auto-fix"
-    :title="props.selectedAutomation.title"
+    :title="selectedAutomation.title"
   >
     <template v-slot:text>
       <eox-jsonform
         id="automation-form"
         :value="initValue"
-        :schema="props.selectedAutomation.inputSchema"
+        :schema="selectedAutomation.inputSchema"
         :customEditorInterfaces="Object.values(CUSTOM_EDITOR_INTERFACES)"
       />
     </template>
@@ -58,7 +65,7 @@ onMounted(() => {
       <v-btn
         color="grey-darken-1"
         variant="text"
-        @click="props.handleAutomationClose"
+        @click="handleAutomationClose"
       >
         Cancel
       </v-btn>

--- a/src/enums.js
+++ b/src/enums.js
@@ -34,6 +34,9 @@ export const AUTOMATION = ref(
   globalThis.automation || GIT_CLERK_CONFIG.automation || [],
 );
 
+export const ALLOWED_ORIGINS =
+  globalThis.allowedOrigins || GIT_CLERK_CONFIG.allowedOrigins || [];
+
 const _initialAutomation = globalThis.automation || GIT_CLERK_CONFIG.automation;
 Object.defineProperty(globalThis, "automation", {
   get() {

--- a/src/helpers/automation.js
+++ b/src/helpers/automation.js
@@ -5,6 +5,7 @@ import {
   stringifyIfNeeded,
 } from "@/helpers";
 import { createAndUpdateFile, getFileDetails } from "@/api";
+import useAutomationStore from "@/stores/automation";
 
 const getLoaderMsg = (type, path, currentMsg) => {
   const messages = {
@@ -16,8 +17,9 @@ const getLoaderMsg = (type, path, currentMsg) => {
 };
 
 export async function runAutomation(props, value, router) {
+  const { selectedAutomation } = useAutomationStore();
   const loaderEle = document.getElementById("loader-text");
-  for (const step of props.selectedAutomation.steps) {
+  for (const step of selectedAutomation.steps) {
     let path =
       typeof step.path === "function"
         ? step.path.constructor.name === "AsyncFunction"

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import i18n from "@/plugins/i18n";
 import { LoadingPlugin } from "vue-loading-overlay";
 import { createPinia } from "pinia";
 import useAutomationStore from "@/stores/automation";
+import { ALLOWED_ORIGINS } from "@/enums";
 
 const app = createApp(App);
 const pinia = createPinia();
@@ -25,7 +26,11 @@ if (window.opener) {
 }
 
 window.addEventListener("message", (event) => {
-  useAutomationStore().setExternalAutomation(event.data);
+  if (ALLOWED_ORIGINS.length > 0 && !ALLOWED_ORIGINS.includes(event.origin)) {
+    throw new Error("Invalid automation URL origin");
+  } else {
+    useAutomationStore().setExternalAutomation(event.data);
+  }
 });
 
 const params = Object.fromEntries(new URLSearchParams(window.location.search));

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import vuetify from "@/plugins/vuetify";
 import i18n from "@/plugins/i18n";
 import { LoadingPlugin } from "vue-loading-overlay";
 import { createPinia } from "pinia";
+import useAutomationStore from "@/stores/automation";
 
 const app = createApp(App);
 const pinia = createPinia();
@@ -18,3 +19,21 @@ app.use(router);
 app.use(i18n);
 app.use(LoadingPlugin);
 app.mount("#app");
+
+if (window.opener) {
+  window.opener.postMessage("automation-ready", "*");
+}
+
+window.addEventListener("message", (event) => {
+  useAutomationStore().setExternalAutomation(event.data);
+});
+
+const params = Object.fromEntries(new URLSearchParams(window.location.search));
+if (Object.keys(params).length) {
+  if (params.automation) {
+    useAutomationStore().setExternalAutomation(params);
+    router.replace({
+      query: {},
+    });
+  }
+}

--- a/src/methods/session-view/handle-automation-method.js
+++ b/src/methods/session-view/handle-automation-method.js
@@ -1,5 +1,6 @@
 import { runAutomation, useLoader } from "@/helpers";
 import { h } from "vue";
+import useAutomationStore from "@/stores/automation";
 
 export default async function handleAutomationMethod(
   props,
@@ -23,7 +24,8 @@ export default async function handleAutomationMethod(
     try {
       await runAutomation(props, value, router);
       loader.hide();
-      props.handleAutomationClose();
+      const { handleAutomationClose } = useAutomationStore();
+      handleAutomationClose();
       props.updateDetails();
     } catch (error) {
       loader.hide();

--- a/src/stores/automation.js
+++ b/src/stores/automation.js
@@ -8,10 +8,14 @@ const useAutomationStore = defineStore("automation", () => {
   const automationDialog = ref(false);
 
   function setExternalAutomation(data) {
-    const parsedData = typeof data === "string" ? JSON.parse(data) : data;
-    if (parsedData.automation) {
-      externalAutomationData.value = parsedData;
-      automation.value = true;
+    try {
+      const parsedData = typeof data === "string" ? JSON.parse(data) : data;
+      if (parsedData.automation) {
+        externalAutomationData.value = parsedData;
+        automation.value = true;
+      }
+    } catch (error) {
+      console.error("Error parsing automation data:", error);
     }
   }
 

--- a/src/stores/automation.js
+++ b/src/stores/automation.js
@@ -1,0 +1,45 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+const useAutomationStore = defineStore("automation", () => {
+  const automation = ref(false);
+  const externalAutomationData = ref({});
+  const selectedAutomation = ref(null);
+  const automationDialog = ref(false);
+
+  function setExternalAutomation(data) {
+    const parsedData = typeof data === "string" ? JSON.parse(data) : data;
+    if (parsedData.automation) {
+      externalAutomationData.value = parsedData;
+      automation.value = true;
+    }
+  }
+
+  function resetExternalAutomation() {
+    automation.value = false;
+    externalAutomationData.value = {};
+  }
+
+  function handleAutomationClick(automation) {
+    selectedAutomation.value = automation;
+    automationDialog.value = true;
+  }
+
+  function handleAutomationClose() {
+    selectedAutomation.value = null;
+    automationDialog.value = false;
+  }
+
+  return {
+    automation,
+    externalAutomationData,
+    selectedAutomation,
+    automationDialog,
+    setExternalAutomation,
+    handleAutomationClick,
+    handleAutomationClose,
+    resetExternalAutomation,
+  };
+});
+
+export default useAutomationStore;

--- a/src/views/SessionView.vue
+++ b/src/views/SessionView.vue
@@ -2,6 +2,7 @@
 import { inject, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { getFilesListFromSession, getSessionDetails } from "@/api/index.js";
+import { storeToRefs } from "pinia";
 import {
   checkStatusMethod,
   queryFilesListMethod,
@@ -19,10 +20,20 @@ import Automation from "@/components/session/Automation.vue";
 import find from "lodash/find";
 import { FileBrowserDrawer } from "@/components/file-browser";
 import { useI18n } from "vue-i18n";
+import useAutomationStore from "@/stores/automation";
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
 const sessionNumber = route.params.sessionNumber;
+
+const automationStore = useAutomationStore();
+const {
+  selectedAutomation,
+  automationDialog,
+  automation,
+  externalAutomationData,
+} = storeToRefs(automationStore);
+const { handleAutomationClick } = automationStore;
 
 const session = ref(null);
 const fileChangesList = ref(null);
@@ -34,8 +45,6 @@ const navButtonConfig = inject("set-nav-button-config");
 const navPaginationItems = inject("set-nav-pagination-items");
 const fileBrowserDrawer = inject("set-file-browser-drawer");
 
-const automationDialog = ref(false);
-const selectedAutomation = ref(null);
 const suggestionList = ref([]);
 
 const updateDetails = async (cache = false) => {
@@ -106,9 +115,11 @@ watch(
       };
     }
 
-    if (route.query.automation && !selectedAutomation.value && newSession) {
-      const automation = find(newAutomation, { id: route.query.automation });
-      if (automation) handleAutomationClick(automation);
+    if (automation.value && !selectedAutomation.value && newSession) {
+      const automationExist = find(newAutomation, {
+        id: externalAutomationData.value.automation,
+      });
+      if (automationExist) handleAutomationClick(automationExist);
     }
   },
   { immediate: true, deep: true },
@@ -122,16 +133,6 @@ const onPageChange = async (newPage) => {
   page.value = newPage;
   await router.push({ query: { ...route.query, page: newPage } });
   await updateDetails(true);
-};
-
-const handleAutomationClick = (automation) => {
-  selectedAutomation.value = automation;
-  automationDialog.value = true;
-};
-
-const handleAutomationClose = () => {
-  selectedAutomation.value = null;
-  automationDialog.value = false;
 };
 </script>
 
@@ -266,7 +267,6 @@ const handleAutomationClose = () => {
   </v-list>
 
   <OffsetPagination v-if="fileChangesList" :page :totalPage :onPageChange />
-
   <!-- Use the Automation component -->
   <v-dialog
     v-if="session"
@@ -274,13 +274,7 @@ const handleAutomationClose = () => {
     v-model="automationDialog"
     max-width="500px"
   >
-    <Automation
-      :handleAutomationClose
-      :updateDetails
-      :automationDialog
-      :selectedAutomation
-      :session
-    />
+    <Automation :updateDetails :session />
   </v-dialog>
 </template>
 

--- a/src/views/SessionsView.vue
+++ b/src/views/SessionsView.vue
@@ -30,6 +30,11 @@ import ListPlaceholder from "@/components/global/ListPlaceholder.vue";
 import CursorPagination from "@/components/global/CursorPagination.vue";
 import { FileBrowserDrawer } from "@/components/file-browser";
 import find from "lodash.find";
+import useAutomationStore from "@/stores/automation";
+import { storeToRefs } from "pinia";
+
+const automationStore = useAutomationStore();
+const { automation, externalAutomationData } = storeToRefs(automationStore);
 
 const route = useRoute();
 const router = useRouter();
@@ -112,11 +117,12 @@ onMounted(async () => {
   navPaginationItems.value = [navPaginationItems.value[0]];
 
   if (
-    (route.query.session || route.query.sessionNumber) &&
-    route.query.automation
+    (externalAutomationData.value.session ||
+      externalAutomationData.value.sessionNumber) &&
+    automation.value
   ) {
-    const sessionNumber = route.query.sessionNumber;
-    newSessionName.value = route.query.session;
+    const sessionNumber = externalAutomationData.value.sessionNumber;
+    newSessionName.value = externalAutomationData.value.session;
 
     let sessionFound = null;
 


### PR DESCRIPTION
## Implementation 
- Added triggering automation through an external website with the help of `postMessage` when `git-clerk` is opened in a new tab. 
- We can pass all the params passed through URL-based automation as a stringified JSON. User can continue using the existing URL query parameter-based automation. 
- All the `automation` related state is managed in `pinia` state
- Added a cypress test for autonation through `postMessage`
- Parent site should contain following code snippet to run the `postMessage` when `automation-ready` is triggered from `git-clerk`. 
```html
<a href="/" target="_blank" rel="opener">Open Git Clerk</a>

<script>
  const mainExampleData = {
    "session": "Test Automation",
    "automation": "add-file",
    "content": "R2l0IGNsZXJrIGF1dG9tYXRpb24=",
    "fileName": "automation.txt"
  }

  let readyAutomation = false;
  window.addEventListener('message', (event) => {
    if (event.data === 'automation-ready') {
      if(!readyAutomation) {
        event.source.postMessage(JSON.stringify(mainExampleData), '*');
        readyAutomation = true;
      }
    }
  });
</script>
```
- Also need to add the origin of the external automation website from where the redirection happens. 
```js 
const allowedOrigins = ["http://example.website"];
globalThis.gitClerkConfig.allowedOrigins = allowedOrigins;
```